### PR TITLE
fix: AORP response formatting errors in task labels, relations, and bulk operations

### DIFF
--- a/src/tools/tasks/bulk/BulkOperationProcessor.ts
+++ b/src/tools/tasks/bulk/BulkOperationProcessor.ts
@@ -189,7 +189,7 @@ export class BulkOperationProcessor {
       content: [
         {
           type: 'text' as const,
-          text: formatAorpAsMarkdown(response as any),
+          text: formatAorpAsMarkdown(response),
         },
       ],
     };
@@ -282,7 +282,7 @@ export class BulkOperationProcessor {
           content: [
             {
               type: 'text' as const,
-              text: formatAorpAsMarkdown(response as any),
+              text: formatAorpAsMarkdown(response),
             },
           ],
         };
@@ -309,7 +309,7 @@ export class BulkOperationProcessor {
       content: [
         {
           type: 'text' as const,
-          text: formatAorpAsMarkdown(response as any),
+          text: formatAorpAsMarkdown(response),
         },
       ],
     };
@@ -496,7 +496,7 @@ export class BulkOperationProcessor {
       content: [
         {
           type: 'text' as const,
-          text: formatAorpAsMarkdown(response as any),
+          text: formatAorpAsMarkdown(response),
         },
       ],
     };


### PR DESCRIPTION
## Summary
- Fix "Cannot read properties of undefined (reading 'key_insight')" error in task label operations
- Fix same error in task relations operations
- Remove unnecessary `as any` casts in bulk operations

## Problem
Several files were manually constructing `StandardTaskResponse` objects and passing them directly to `formatAorpAsMarkdown()`, which expects an `AorpResponse` object. This caused runtime errors when trying to access `response.immediate.key_insight`.

## Solution
Replace manual response construction with `createStandardResponse()` which properly returns AORP-compatible objects.

## Affected Files
- `src/tools/tasks/labels.ts` - `applyLabels()`, `removeLabels()`, `listTaskLabels()`
- `src/tools/tasks-relations.ts` - `relate`, `unrelate`, `relations`
- `src/tools/tasks/bulk/BulkOperationProcessor.ts` - removed unnecessary `as any` casts

## Test plan
- [x] Build passes
- [x] Live tested: `list-labels`, `remove-label`, `apply-label`
- [x] Live tested: `relations`
- [x] Live tested: `bulk-create`, `bulk-update`, `bulk-delete`
- [x] No new test failures (pre-existing failures unrelated to this change)