### PR TITLE
feat: Add tool blocklist via VIKUNJA_DISABLED_TOOLS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,19 @@ EXPORT_TOOL_TIMEOUT=600000                # Tool execution timeout in millisecon
 VIKUNJA_ENABLE_SERVER_SIDE_FILTERING=true
 
 # =============================================================================
+# TOOL BLOCKLIST CONFIGURATION
+# =============================================================================
+
+# Disable specific tools to reduce token usage in AI assistants (optional)
+# Comma-separated list of tools to disable
+# Core tools (auth, tasks) cannot be disabled
+#
+# Blockable tools: projects, labels, teams, filters, templates, webhooks, batch-import, users, export
+#
+# Example: Disable tools you don't need to reduce token consumption
+# VIKUNJA_DISABLED_TOOLS=teams,templates,webhooks,filters,batch-import
+
+# =============================================================================
 # ENVIRONMENT PROFILES
 # =============================================================================
 

--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,38 @@ FILTER_MAX_LENGTH=1000          # Maximum filter string length (default: 1000)
 FILTER_MAX_VALUE_LENGTH=200     # Maximum individual value length (default: 200)
 ```
 
+#### Tool Blocklist Configuration
+
+Disable specific tools to reduce token usage in AI assistants. This is useful when you don't need certain tools and want to minimize the tool definitions sent to the AI model.
+
+```bash
+# Disable specific tools (comma-separated list)
+# Core tools (auth, tasks) cannot be disabled
+VIKUNJA_DISABLED_TOOLS=teams,templates,webhooks,filters,batch-import
+```
+
+**Blockable Tools:**
+| Tool | Description |
+|------|-------------|
+| `projects` | Project management operations |
+| `labels` | Label management operations |
+| `teams` | Team operations |
+| `filters` | Saved filter management |
+| `templates` | Project template operations |
+| `webhooks` | Webhook management |
+| `batch-import` | Batch import operations |
+| `users` | User management (requires JWT) |
+| `export` | Data export (requires JWT) |
+
+**Protected Core Tools (cannot be disabled):**
+- `auth` - Authentication management
+- `tasks` - Task operations
+
+**Notes:**
+- Unknown tool names are logged as warnings but ignored
+- Without this variable set, all tools are registered (backwards compatible)
+- Token savings depend on which tools you disable
+
 For detailed rate limiting configuration, see [`docs/RATE_LIMITING.md`](docs/RATE_LIMITING.md).
 
 ## Roadmap

--- a/src/tools/blocklist.ts
+++ b/src/tools/blocklist.ts
@@ -1,0 +1,133 @@
+/**
+ * Tool Blocklist Management
+ * Allows users to disable specific tools via VIKUNJA_DISABLED_TOOLS environment variable
+ * to reduce token usage in MCP clients.
+ *
+ * Core tools (auth, tasks) cannot be disabled as they are essential for basic functionality.
+ */
+
+/**
+ * Core tools that cannot be disabled
+ */
+export const CORE_TOOLS = ['auth', 'tasks'] as const;
+
+/**
+ * Tools that can be disabled via blocklist
+ */
+export const BLOCKABLE_TOOLS = [
+  'projects',
+  'labels',
+  'teams',
+  'filters',
+  'templates',
+  'webhooks',
+  'batch-import',
+  'users',
+  'export',
+] as const;
+
+/**
+ * All known tool names (core + blockable)
+ */
+export const ALL_TOOLS = [...CORE_TOOLS, ...BLOCKABLE_TOOLS] as const;
+
+export type CoreTool = (typeof CORE_TOOLS)[number];
+export type BlockableTool = (typeof BLOCKABLE_TOOLS)[number];
+export type ToolName = (typeof ALL_TOOLS)[number];
+
+/**
+ * Result of blocklist validation
+ */
+export interface BlocklistValidation {
+  /** Valid blockable tools found in blocklist */
+  valid: string[];
+  /** Unknown tool names that don't exist */
+  invalid: string[];
+  /** Core tools that were attempted to be blocked (ignored) */
+  protected: string[];
+}
+
+/**
+ * Parse the VIKUNJA_DISABLED_TOOLS environment variable into a Set of tool names
+ *
+ * @param envVar - The raw environment variable value (comma-separated list)
+ * @returns Set of tool names to block
+ */
+export function parseBlocklist(envVar?: string): Set<string> {
+  if (!envVar || envVar.trim() === '') {
+    return new Set();
+  }
+
+  const tools = envVar
+    .split(',')
+    .map((tool) => tool.trim())
+    .filter((tool) => tool.length > 0);
+
+  return new Set(tools);
+}
+
+/**
+ * Check if a tool is blocked
+ *
+ * Core tools (auth, tasks) are never blocked, even if they appear in the blocklist.
+ *
+ * @param toolName - The name of the tool to check
+ * @param blocklist - Set of blocked tool names
+ * @returns true if the tool should be blocked, false otherwise
+ */
+export function isToolBlocked(toolName: string, blocklist: Set<string>): boolean {
+  // Core tools are never blocked
+  if ((CORE_TOOLS as readonly string[]).includes(toolName)) {
+    return false;
+  }
+
+  return blocklist.has(toolName);
+}
+
+/**
+ * Validate a blocklist and categorize its entries
+ *
+ * @param blocklist - Set of tool names from the blocklist
+ * @returns Categorized validation result
+ */
+export function validateBlocklist(blocklist: Set<string>): BlocklistValidation {
+  const valid: string[] = [];
+  const invalid: string[] = [];
+  const protected_: string[] = [];
+
+  for (const tool of blocklist) {
+    if ((CORE_TOOLS as readonly string[]).includes(tool)) {
+      protected_.push(tool);
+    } else if ((BLOCKABLE_TOOLS as readonly string[]).includes(tool)) {
+      valid.push(tool);
+    } else {
+      invalid.push(tool);
+    }
+  }
+
+  return {
+    valid,
+    invalid,
+    protected: protected_,
+  };
+}
+
+/**
+ * Log warnings for invalid blocklist entries
+ *
+ * @param validation - The validation result from validateBlocklist
+ */
+export function logBlocklistWarnings(validation: BlocklistValidation): void {
+  if (validation.invalid.length > 0) {
+    console.warn(
+      `[WARN] Unknown tools in VIKUNJA_DISABLED_TOOLS will be ignored: ${validation.invalid.join(', ')}`
+    );
+    console.warn(`[WARN] Valid tool names are: ${BLOCKABLE_TOOLS.join(', ')}`);
+  }
+
+  if (validation.protected.length > 0) {
+    console.warn(
+      `[WARN] Core tools cannot be disabled and will remain active: ${validation.protected.join(', ')}`
+    );
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,9 +3,10 @@
  * Registers all Vikunja tools with the MCP server using conditional registration
  *
  * Registration Strategy:
- * - Core tools (auth, tasks): Always registered
+ * - Core tools (auth, tasks): Always registered (cannot be disabled)
  * - Client-dependent tools: Only registered when clientFactory is available
  * - JWT-restricted tools (users, export): Only registered with JWT authentication
+ * - Blocklist support: Tools can be disabled via VIKUNJA_DISABLED_TOOLS env var
  *
  * This approach ensures tool availability matches authentication capabilities
  * and prevents API errors from unsupported token types.
@@ -26,40 +27,68 @@ import { registerTemplatesTool } from './templates';
 import { registerWebhooksTool } from './webhooks';
 import { registerBatchImportTool } from './batch-import';
 import { registerExportTool } from './export';
+import {
+  parseBlocklist,
+  validateBlocklist,
+  logBlocklistWarnings,
+  isToolBlocked,
+} from './blocklist';
 
 export function registerTools(
-  server: McpServer, 
-  authManager: AuthManager, 
+  server: McpServer,
+  authManager: AuthManager,
   clientFactory?: VikunjaClientFactory
 ): void {
-  // Register tools with conditional availability based on dependencies and authentication
+  // Parse and validate blocklist from environment variable
+  const blocklist = parseBlocklist(process.env.VIKUNJA_DISABLED_TOOLS);
+  const validation = validateBlocklist(blocklist);
+  logBlocklistWarnings(validation);
 
+  // Core tools - always registered (cannot be disabled)
   registerAuthTool(server, authManager);
   registerTasksTool(server, authManager, clientFactory);
 
   // Only register tools that require clientFactory if it's available
   if (clientFactory) {
-    registerProjectsTool(server, authManager, clientFactory);
-    registerLabelsTool(server, authManager, clientFactory);
-    registerTeamsTool(server, authManager, clientFactory);
+    // Blockable tools - check blocklist before registering
+    if (!isToolBlocked('projects', blocklist)) {
+      registerProjectsTool(server, authManager, clientFactory);
+    }
 
-    // Register filters tool (needs auth manager for session-scoped storage)
-    registerFiltersTool(server, authManager, clientFactory);
+    if (!isToolBlocked('labels', blocklist)) {
+      registerLabelsTool(server, authManager, clientFactory);
+    }
 
-    // Register templates tool
-    registerTemplatesTool(server, authManager, clientFactory);
+    if (!isToolBlocked('teams', blocklist)) {
+      registerTeamsTool(server, authManager, clientFactory);
+    }
 
-    // Register webhooks tool
-    registerWebhooksTool(server, authManager, clientFactory);
+    if (!isToolBlocked('filters', blocklist)) {
+      registerFiltersTool(server, authManager, clientFactory);
+    }
 
-    // Register batch import tool
-    registerBatchImportTool(server, authManager, clientFactory);
+    if (!isToolBlocked('templates', blocklist)) {
+      registerTemplatesTool(server, authManager, clientFactory);
+    }
+
+    if (!isToolBlocked('webhooks', blocklist)) {
+      registerWebhooksTool(server, authManager, clientFactory);
+    }
+
+    if (!isToolBlocked('batch-import', blocklist)) {
+      registerBatchImportTool(server, authManager, clientFactory);
+    }
 
     // Register user and export tools conditionally (preserving backward compatibility)
     // NOTE: The permission infrastructure is available for future migration
     if (authManager.isAuthenticated() && authManager.getAuthType() === 'jwt') {
-      registerUsersTool(server, authManager, clientFactory);
-      registerExportTool(server, authManager, clientFactory);
+      if (!isToolBlocked('users', blocklist)) {
+        registerUsersTool(server, authManager, clientFactory);
+      }
+
+      if (!isToolBlocked('export', blocklist)) {
+        registerExportTool(server, authManager, clientFactory);
+      }
     }
   }
 }

--- a/tests/tools/blocklist.test.ts
+++ b/tests/tools/blocklist.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for Tool Blocklist functionality
+ */
+
+import {
+  parseBlocklist,
+  isToolBlocked,
+  validateBlocklist,
+  logBlocklistWarnings,
+  CORE_TOOLS,
+  BLOCKABLE_TOOLS,
+  ALL_TOOLS,
+} from '../../src/tools/blocklist';
+
+describe('Tool Blocklist', () => {
+  describe('Constants', () => {
+    it('should define core tools that cannot be blocked', () => {
+      expect(CORE_TOOLS).toContain('auth');
+      expect(CORE_TOOLS).toContain('tasks');
+      expect(CORE_TOOLS).toHaveLength(2);
+    });
+
+    it('should define all blockable tools', () => {
+      expect(BLOCKABLE_TOOLS).toContain('projects');
+      expect(BLOCKABLE_TOOLS).toContain('labels');
+      expect(BLOCKABLE_TOOLS).toContain('teams');
+      expect(BLOCKABLE_TOOLS).toContain('filters');
+      expect(BLOCKABLE_TOOLS).toContain('templates');
+      expect(BLOCKABLE_TOOLS).toContain('webhooks');
+      expect(BLOCKABLE_TOOLS).toContain('batch-import');
+      expect(BLOCKABLE_TOOLS).toContain('users');
+      expect(BLOCKABLE_TOOLS).toContain('export');
+      expect(BLOCKABLE_TOOLS).toHaveLength(9);
+    });
+
+    it('should have ALL_TOOLS as combination of core and blockable', () => {
+      expect(ALL_TOOLS).toHaveLength(CORE_TOOLS.length + BLOCKABLE_TOOLS.length);
+      for (const tool of CORE_TOOLS) {
+        expect(ALL_TOOLS).toContain(tool);
+      }
+      for (const tool of BLOCKABLE_TOOLS) {
+        expect(ALL_TOOLS).toContain(tool);
+      }
+    });
+  });
+
+  describe('parseBlocklist', () => {
+    it('should return empty set for undefined input', () => {
+      const result = parseBlocklist(undefined);
+      expect(result.size).toBe(0);
+    });
+
+    it('should return empty set for empty string', () => {
+      const result = parseBlocklist('');
+      expect(result.size).toBe(0);
+    });
+
+    it('should return empty set for whitespace-only string', () => {
+      const result = parseBlocklist('   ');
+      expect(result.size).toBe(0);
+    });
+
+    it('should parse single tool name', () => {
+      const result = parseBlocklist('teams');
+      expect(result.size).toBe(1);
+      expect(result.has('teams')).toBe(true);
+    });
+
+    it('should parse multiple comma-separated tool names', () => {
+      const result = parseBlocklist('teams,templates,webhooks');
+      expect(result.size).toBe(3);
+      expect(result.has('teams')).toBe(true);
+      expect(result.has('templates')).toBe(true);
+      expect(result.has('webhooks')).toBe(true);
+    });
+
+    it('should trim whitespace from tool names', () => {
+      const result = parseBlocklist('  teams , templates  ,  webhooks  ');
+      expect(result.size).toBe(3);
+      expect(result.has('teams')).toBe(true);
+      expect(result.has('templates')).toBe(true);
+      expect(result.has('webhooks')).toBe(true);
+    });
+
+    it('should filter out empty entries from multiple commas', () => {
+      const result = parseBlocklist('teams,,templates,,,webhooks');
+      expect(result.size).toBe(3);
+      expect(result.has('teams')).toBe(true);
+      expect(result.has('templates')).toBe(true);
+      expect(result.has('webhooks')).toBe(true);
+    });
+
+    it('should handle trailing comma', () => {
+      const result = parseBlocklist('teams,templates,');
+      expect(result.size).toBe(2);
+      expect(result.has('teams')).toBe(true);
+      expect(result.has('templates')).toBe(true);
+    });
+
+    it('should handle leading comma', () => {
+      const result = parseBlocklist(',teams,templates');
+      expect(result.size).toBe(2);
+      expect(result.has('teams')).toBe(true);
+      expect(result.has('templates')).toBe(true);
+    });
+
+    it('should deduplicate repeated tool names', () => {
+      const result = parseBlocklist('teams,templates,teams,webhooks,teams');
+      expect(result.size).toBe(3);
+      expect(result.has('teams')).toBe(true);
+      expect(result.has('templates')).toBe(true);
+      expect(result.has('webhooks')).toBe(true);
+    });
+  });
+
+  describe('isToolBlocked', () => {
+    it('should return false for empty blocklist', () => {
+      const blocklist = new Set<string>();
+      expect(isToolBlocked('projects', blocklist)).toBe(false);
+    });
+
+    it('should return true for tool in blocklist', () => {
+      const blocklist = new Set(['teams', 'templates']);
+      expect(isToolBlocked('teams', blocklist)).toBe(true);
+      expect(isToolBlocked('templates', blocklist)).toBe(true);
+    });
+
+    it('should return false for tool not in blocklist', () => {
+      const blocklist = new Set(['teams', 'templates']);
+      expect(isToolBlocked('projects', blocklist)).toBe(false);
+      expect(isToolBlocked('labels', blocklist)).toBe(false);
+    });
+
+    it('should never block core tool "auth" even if in blocklist', () => {
+      const blocklist = new Set(['auth', 'teams']);
+      expect(isToolBlocked('auth', blocklist)).toBe(false);
+    });
+
+    it('should never block core tool "tasks" even if in blocklist', () => {
+      const blocklist = new Set(['tasks', 'teams']);
+      expect(isToolBlocked('tasks', blocklist)).toBe(false);
+    });
+
+    it('should protect all core tools', () => {
+      const blocklist = new Set([...CORE_TOOLS, 'teams']);
+      for (const coreTool of CORE_TOOLS) {
+        expect(isToolBlocked(coreTool, blocklist)).toBe(false);
+      }
+    });
+
+    it('should block all blockable tools when in blocklist', () => {
+      const blocklist = new Set([...BLOCKABLE_TOOLS]);
+      for (const blockableTool of BLOCKABLE_TOOLS) {
+        expect(isToolBlocked(blockableTool, blocklist)).toBe(true);
+      }
+    });
+  });
+
+  describe('validateBlocklist', () => {
+    it('should return empty arrays for empty blocklist', () => {
+      const blocklist = new Set<string>();
+      const result = validateBlocklist(blocklist);
+      expect(result.valid).toHaveLength(0);
+      expect(result.invalid).toHaveLength(0);
+      expect(result.protected).toHaveLength(0);
+    });
+
+    it('should categorize valid blockable tools', () => {
+      const blocklist = new Set(['teams', 'templates', 'webhooks']);
+      const result = validateBlocklist(blocklist);
+      expect(result.valid).toContain('teams');
+      expect(result.valid).toContain('templates');
+      expect(result.valid).toContain('webhooks');
+      expect(result.valid).toHaveLength(3);
+      expect(result.invalid).toHaveLength(0);
+      expect(result.protected).toHaveLength(0);
+    });
+
+    it('should categorize unknown tools as invalid', () => {
+      const blocklist = new Set(['unknown-tool', 'fake-tool', 'teams']);
+      const result = validateBlocklist(blocklist);
+      expect(result.valid).toContain('teams');
+      expect(result.valid).toHaveLength(1);
+      expect(result.invalid).toContain('unknown-tool');
+      expect(result.invalid).toContain('fake-tool');
+      expect(result.invalid).toHaveLength(2);
+      expect(result.protected).toHaveLength(0);
+    });
+
+    it('should categorize core tools as protected', () => {
+      const blocklist = new Set(['auth', 'tasks', 'teams']);
+      const result = validateBlocklist(blocklist);
+      expect(result.valid).toContain('teams');
+      expect(result.valid).toHaveLength(1);
+      expect(result.invalid).toHaveLength(0);
+      expect(result.protected).toContain('auth');
+      expect(result.protected).toContain('tasks');
+      expect(result.protected).toHaveLength(2);
+    });
+
+    it('should handle mixed valid, invalid, and protected tools', () => {
+      const blocklist = new Set([
+        'teams', // valid
+        'templates', // valid
+        'auth', // protected
+        'tasks', // protected
+        'unknown1', // invalid
+        'unknown2', // invalid
+      ]);
+      const result = validateBlocklist(blocklist);
+      expect(result.valid).toHaveLength(2);
+      expect(result.valid).toContain('teams');
+      expect(result.valid).toContain('templates');
+      expect(result.protected).toHaveLength(2);
+      expect(result.protected).toContain('auth');
+      expect(result.protected).toContain('tasks');
+      expect(result.invalid).toHaveLength(2);
+      expect(result.invalid).toContain('unknown1');
+      expect(result.invalid).toContain('unknown2');
+    });
+
+    it('should validate all blockable tools correctly', () => {
+      const blocklist = new Set([...BLOCKABLE_TOOLS]);
+      const result = validateBlocklist(blocklist);
+      expect(result.valid).toHaveLength(BLOCKABLE_TOOLS.length);
+      for (const tool of BLOCKABLE_TOOLS) {
+        expect(result.valid).toContain(tool);
+      }
+      expect(result.invalid).toHaveLength(0);
+      expect(result.protected).toHaveLength(0);
+    });
+  });
+
+  describe('logBlocklistWarnings', () => {
+    let consoleWarnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should not log anything when all entries are valid', () => {
+      const validation = {
+        valid: ['teams', 'templates'],
+        invalid: [],
+        protected: [],
+      };
+      logBlocklistWarnings(validation);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should log warning for invalid tools', () => {
+      const validation = {
+        valid: ['teams'],
+        invalid: ['unknown-tool', 'fake-tool'],
+        protected: [],
+      };
+      logBlocklistWarnings(validation);
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown tools in VIKUNJA_DISABLED_TOOLS')
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('unknown-tool')
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('fake-tool')
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Valid tool names are')
+      );
+    });
+
+    it('should log warning for protected core tools', () => {
+      const validation = {
+        valid: ['teams'],
+        invalid: [],
+        protected: ['auth', 'tasks'],
+      };
+      logBlocklistWarnings(validation);
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Core tools cannot be disabled')
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('auth'));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('tasks'));
+    });
+
+    it('should log warnings for both invalid and protected tools', () => {
+      const validation = {
+        valid: ['teams'],
+        invalid: ['unknown-tool'],
+        protected: ['auth'],
+      };
+      logBlocklistWarnings(validation);
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(3); // 2 for invalid (warning + valid list), 1 for protected
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown tools')
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Core tools cannot be disabled')
+      );
+    });
+  });
+
+  describe('Integration: Full blocklist workflow', () => {
+    let consoleWarnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should handle realistic blocklist scenario', () => {
+      // Simulate: VIKUNJA_DISABLED_TOOLS=teams,templates,webhooks,filters,batch-import
+      const envValue = 'teams,templates,webhooks,filters,batch-import';
+      const blocklist = parseBlocklist(envValue);
+      const validation = validateBlocklist(blocklist);
+      logBlocklistWarnings(validation);
+
+      expect(validation.valid).toHaveLength(5);
+      expect(validation.invalid).toHaveLength(0);
+      expect(validation.protected).toHaveLength(0);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // Verify blocking behavior
+      expect(isToolBlocked('teams', blocklist)).toBe(true);
+      expect(isToolBlocked('templates', blocklist)).toBe(true);
+      expect(isToolBlocked('webhooks', blocklist)).toBe(true);
+      expect(isToolBlocked('filters', blocklist)).toBe(true);
+      expect(isToolBlocked('batch-import', blocklist)).toBe(true);
+
+      // Verify non-blocked tools
+      expect(isToolBlocked('projects', blocklist)).toBe(false);
+      expect(isToolBlocked('labels', blocklist)).toBe(false);
+      expect(isToolBlocked('users', blocklist)).toBe(false);
+      expect(isToolBlocked('export', blocklist)).toBe(false);
+
+      // Verify core tools are never blocked
+      expect(isToolBlocked('auth', blocklist)).toBe(false);
+      expect(isToolBlocked('tasks', blocklist)).toBe(false);
+    });
+
+    it('should handle scenario with typos and core tools', () => {
+      // Simulate user error: trying to block core tools and typos
+      const envValue = 'auth,tasks,teams,templtes,webhooks'; // 'templtes' is typo
+      const blocklist = parseBlocklist(envValue);
+      const validation = validateBlocklist(blocklist);
+      logBlocklistWarnings(validation);
+
+      expect(validation.valid).toContain('teams');
+      expect(validation.valid).toContain('webhooks');
+      expect(validation.valid).toHaveLength(2);
+      expect(validation.invalid).toContain('templtes');
+      expect(validation.invalid).toHaveLength(1);
+      expect(validation.protected).toContain('auth');
+      expect(validation.protected).toContain('tasks');
+      expect(validation.protected).toHaveLength(2);
+
+      // Should have warned about invalid and protected
+      expect(consoleWarnSpy).toHaveBeenCalled();
+
+      // Core tools should still not be blocked
+      expect(isToolBlocked('auth', blocklist)).toBe(false);
+      expect(isToolBlocked('tasks', blocklist)).toBe(false);
+    });
+
+    it('should handle empty/no blocklist for backwards compatibility', () => {
+      const blocklist = parseBlocklist(undefined);
+      const validation = validateBlocklist(blocklist);
+      logBlocklistWarnings(validation);
+
+      expect(blocklist.size).toBe(0);
+      expect(validation.valid).toHaveLength(0);
+      expect(validation.invalid).toHaveLength(0);
+      expect(validation.protected).toHaveLength(0);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // No tools should be blocked
+      for (const tool of ALL_TOOLS) {
+        // Core tools are never blocked anyway
+        if (!(CORE_TOOLS as readonly string[]).includes(tool)) {
+          expect(isToolBlocked(tool, blocklist)).toBe(false);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implement configurable tool blocklist to reduce token usage in MCP clients (~8k tokens for 9 tools). Users can disable specific tools via environment variable.

## Changes

- **New**: `VIKUNJA_DISABLED_TOOLS` environment variable (comma-separated list)
- **Protected**: Core tools `auth` and `tasks` cannot be disabled
- **Graceful**: Unknown tool names warned but ignored
- **Backwards compatible**: No env var = all tools registered

## Blockable Tools

| Tool | Description |
|------|-------------|
| `projects` | Project management |
| `labels` | Label management |
| `teams` | Team operations |
| `filters` | Saved filter management |
| `templates` | Project templates |
| `webhooks` | Webhook management |
| `batch-import` | Batch import |
| `users` | User management (JWT only) |
| `export` | Data export (JWT only) |

## Example

```json
{
  "env": {
    "VIKUNJA_DISABLED_TOOLS": "teams,templates,webhooks,filters,batch-import"
  }
}
```

## Test Plan

- [x] Unit tests (37 tests in `blocklist.test.ts`)
- [x] Integration tests (8 tests in `index.test.ts`)
- [x] Manual testing with Claude Desktop MCP client
- [x] TypeScript type check passes
- [x] No lint errors in new code