### PR TITLE
fix: include due_date in STANDARD verbosity level

### DIFF
--- a/src/transforms/base.ts
+++ b/src/transforms/base.ts
@@ -220,12 +220,12 @@ export const FIELD_CATEGORIES = {
   // Context fields (included in standard and above)
   CONTEXT_FIELDS: [
     'description', 'project_id', 'project', 'labels', 'assignees',
-    'creator', 'created_by', 'priority', 'identifier'
+    'creator', 'created_by', 'priority', 'identifier', 'due_date'
   ],
 
   // Scheduling fields (included in detailed and above)
   SCHEDULING_FIELDS: [
-    'due_date', 'start_date', 'end_date', 'reminders', 'created_at',
+    'start_date', 'end_date', 'reminders', 'created_at',
     'updated_at', 'completed_at', 'repeat_after'
   ],
 

--- a/src/transforms/field-selector.ts
+++ b/src/transforms/field-selector.ts
@@ -39,10 +39,10 @@ export class FieldSelector {
       { fieldName: 'description', category: FieldCategory.CONTEXT, minVerbosity: Verbosity.STANDARD },
       { fieldName: 'project_id', category: FieldCategory.CONTEXT, minVerbosity: Verbosity.STANDARD },
       { fieldName: 'priority', category: FieldCategory.CONTEXT, minVerbosity: Verbosity.STANDARD },
+      { fieldName: 'due_date', category: FieldCategory.CONTEXT, minVerbosity: Verbosity.STANDARD },
     ];
 
     const schedulingFields: FieldDefinition[] = [
-      { fieldName: 'due_date', category: FieldCategory.SCHEDULING, minVerbosity: Verbosity.DETAILED },
       { fieldName: 'created_at', category: FieldCategory.SCHEDULING, minVerbosity: Verbosity.DETAILED },
       { fieldName: 'updated_at', category: FieldCategory.SCHEDULING, minVerbosity: Verbosity.DETAILED },
     ];

--- a/tests/transforms/field-selector.test.ts
+++ b/tests/transforms/field-selector.test.ts
@@ -39,13 +39,14 @@ describe('Field Selector', () => {
 
   describe('Standard Verbosity', () => {
     it('should select core and context fields for standard verbosity', () => {
-      const availableFields = ['id', 'title', 'done', 'description', 'priority', 'due_date'];
+      // due_date is now in CONTEXT (STANDARD) since it's essential for task management
+      const availableFields = ['id', 'title', 'done', 'description', 'priority', 'due_date', 'created_at'];
       const config = { verbosity: Verbosity.STANDARD };
 
       const result = fieldSelector.selectFields(config, availableFields);
 
-      expect(result.includedFields).toEqual(['id', 'title', 'done', 'description', 'priority']);
-      expect(result.excludedFields).toEqual(['due_date']);
+      expect(result.includedFields).toEqual(['id', 'title', 'done', 'description', 'priority', 'due_date']);
+      expect(result.excludedFields).toEqual(['created_at']); // created_at remains in SCHEDULING
       expect(result.activeCategories).toEqual([FieldCategory.CORE, FieldCategory.CONTEXT]);
     });
 
@@ -95,7 +96,8 @@ describe('Field Selector', () => {
 
   describe('Complete Verbosity', () => {
     it('should select all available fields for complete verbosity', () => {
-      const availableFields = ['id', 'title', 'done', 'description', 'priority', 'due_date', 'hex_color', 'position', 'index'];
+      // Note: due_date is now in CONTEXT, so we need created_at for SCHEDULING category
+      const availableFields = ['id', 'title', 'done', 'description', 'priority', 'due_date', 'created_at', 'hex_color', 'position', 'index'];
       const config = { verbosity: Verbosity.COMPLETE };
 
       const result = fieldSelector.selectFields(config, availableFields);
@@ -194,10 +196,10 @@ describe('Field Selector', () => {
       expect(idField?.category).toBe(FieldCategory.CORE);
       expect(idField?.minVerbosity).toBe(Verbosity.MINIMAL);
 
-      // Check scheduling field definitions
+      // Check context field definitions (due_date moved to CONTEXT for STANDARD availability)
       const dueDateField = result.fieldDefinitions.find(f => f.fieldName === 'due_date');
-      expect(dueDateField?.category).toBe(FieldCategory.SCHEDULING);
-      expect(dueDateField?.minVerbosity).toBe(Verbosity.DETAILED);
+      expect(dueDateField?.category).toBe(FieldCategory.CONTEXT);
+      expect(dueDateField?.minVerbosity).toBe(Verbosity.STANDARD);
     });
 
     it('should infer categories for unknown fields when included via override', () => {


### PR DESCRIPTION
## Problem

When using `vikunja_tasks` with the default (STANDARD) verbosity, the `due_date` field is not returned in the response. This is problematic because:

1. **Task deadlines are essential context** - Users need to see when tasks are due to understand urgency and prioritize work
2. **Current behavior requires explicit verbosity override** - To get `due_date`, users must request `DETAILED` verbosity, which also pulls in many other fields they may not need
3. **Inconsistent with user expectations** - Most task management tools consider due dates as core task information, not optional metadata

### Analysis

Looking at the current field categorization in `transforms/base.ts`:

```typescript
CONTEXT_FIELDS: [
  'description', 'project_id', 'project', 'labels', 'assignees',
  'creator', 'created_by', 'priority', 'identifier'
],

SCHEDULING_FIELDS: [
  'due_date', 'start_date', 'end_date', 'reminders', 'created_at',
  'updated_at', 'completed_at', 'repeat_after'
],
```

The `due_date` field was grouped with pure scheduling/audit fields like `created_at` and `updated_at`. However, `due_date` serves a fundamentally different purpose:

- **`due_date`**: Active planning information that affects task prioritization and workflow decisions
- **`created_at/updated_at`**: Passive audit/metadata information

## Solution

Move `due_date` from `SCHEDULING` category to `CONTEXT` category, making it available at `STANDARD` verbosity level.

### Changes

| File | Change |
|------|--------|
| `src/transforms/field-selector.ts` | Recategorize `due_date` field definition from SCHEDULING to CONTEXT |
| `src/transforms/base.ts` | Move `due_date` in `FIELD_CATEGORIES` constant |
| `tests/transforms/field-selector.test.ts` | Update tests to reflect new categorization |

## Impact

- **STANDARD verbosity** now includes `due_date` (in addition to existing fields)
- **DETAILED verbosity** behavior unchanged (still includes all scheduling fields)
- **No breaking changes** - responses only gain information, never lose it

## Test Plan

- [x] All transform tests pass
- [x] Verified no new test failures compared to main branch
- [x] Field selector correctly categorizes `due_date` as CONTEXT
- [x] STANDARD verbosity now includes `due_date` in output