### PR TITLE
fix: move zod from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "object-sizeof": "^2.6.5",
     "opossum": "^9.0.0",
     "tslib": "^2.8.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
@@ -85,8 +86,7 @@
     "prettier": "^3.0.0",
     "ts-jest": "^29.4.1",
     "tsx": "^4.0.0",
-    "typescript": "^5.0.0",
-    "zod": "^3.25.28"
+    "typescript": "^5.0.0"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
## Summary
- Move `zod` from `devDependencies` to `dependencies` in package.json

## Problem
`zod` is imported at runtime in tool registration files (e.g., `src/tools/auth.ts`) but was listed as a `devDependency`. When the package is installed via `npx -y @democratize-technology/vikunja-mcp`, devDependencies are not installed.

This causes the MCP server to fail with:
```
Cannot read properties of undefined (reading '_zod')
```

The server reports `Capabilities: none` because the `tools/list` method crashes before it can return the tool definitions.

## Test plan
- Install via `npx -y @democratize-technology/vikunja-mcp`
- Send MCP `initialize` and `tools/list` requests
- Verify tools are returned without errors