### PR TITLE
fix: add post-assignment verification to detect silent API failures

### DIFF
--- a/tests/tools/tasks/assignees.test.ts
+++ b/tests/tools/tasks/assignees.test.ts
@@ -59,6 +59,27 @@ describe('Assignee operations', () => {
       expect(markdown).toContain('Users assigned to task successfully');
     });
 
+    it('should warn when assignees are not persisted (silent API failure)', async () => {
+      // Simulate the Vikunja API silently not persisting assignees
+      const mockTaskNoAssignees = {
+        id: 123,
+        title: 'Test Task',
+        assignees: [], // API returned success but assignees didn't persist
+      };
+
+      mockClient.tasks.bulkAssignUsersToTask.mockResolvedValue({});
+      mockClient.tasks.getTask.mockResolvedValue(mockTaskNoAssignees);
+
+      const result = await assignUsers({
+        id: 123,
+        assignees: [1, 2],
+      });
+
+      const markdown = result.content[0].text;
+      expect(markdown).toContain('not persisted');
+      expect(markdown).toContain('JWT authentication');
+    });
+
     it('should throw error when task id is missing', async () => {
       await expect(assignUsers({ assignees: [1, 2] })).rejects.toThrow(
         'Task id is required for assign operation'


### PR DESCRIPTION
## Summary

Adds post-assignment verification to catch the known Vikunja API limitation where bulk assignee operations return HTTP 200 but silently fail to persist when using API token auth.

## Problem

Users reported in #15 that assigning users to tasks via any code path (`vikunja_task_assignees`, `vikunja_task_crud`, `vikunja_task_bulk`) reports success but assignments don't persist. The root cause is an upstream Vikunja API limitation with API token authentication.

## Solution

Rather than silently reporting success, we now **verify** that assignees actually persisted by re-fetching the task after the assign call and comparing requested vs actual assignee IDs.

### Changes
- **`AssigneeOperationsService`** — new `verifyAssignees()` method that re-fetches the task and returns any IDs that didn't persist
- **`assignUsers()`** — calls verification after assign, surfaces a clear warning with JWT auth suggestion if persistence failed
- **`TaskCreationService`** — verifies assignees after task creation, includes warning in response message
- **Test** — new test case for silent failure detection

## What this does NOT do

This doesn't fix the upstream Vikunja API limitation — it surfaces it clearly instead of letting it fail silently.

## Test plan

- [x] TypeScript compilation passes
- [x] Existing assignee tests pass (31/32, 1 pre-existing failure in listAssignees)
- [x] TaskCreationService tests pass (21/21)
- [x] New verification test passes

Relates to #15