### PR TITLE
Pin zod to 3.25.28 to avoid tools/list crashes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8163,9 +8163,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "3.25.28",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
+      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
       "license": "MIT",
       "peer": true,
       "funding": {


### PR DESCRIPTION
This PR keeps the zod dependency aligned with 3.25.28 for tools/list stability. The repo already had the package.json dependency on ^3.25.28; this change resets the lockfile to zod 3.25.28 so installs do not drift to a newer patch release.