### PR TITLE
fix: use two-argument z.record() for Zod v4 compatibility

### DIFF
--- a/src/tools/filters.ts
+++ b/src/tools/filters.ts
@@ -124,7 +124,7 @@ export function registerFiltersTool(server: McpServer, authManager: AuthManager,
     'Manage and build advanced filters for tasks and projects with validation',
     {
       action: z.enum(['list', 'get', 'create', 'update', 'delete', 'build', 'validate']),
-      parameters: z.record(z.unknown()),
+      parameters: z.record(z.string(), z.unknown()),
     },
     async ({ action, parameters }) => {
       logger.info(`Executing vikunja_filters action: ${action}`);

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -61,7 +61,7 @@ export function registerTemplatesTool(server: McpServer, authManager: AuthManage
       // Instantiation fields
       projectName: z.string().optional(),
       parentProjectId: z.number().optional(),
-      variables: z.record(z.string()).optional(),
+      variables: z.record(z.string(), z.string()).optional(),
     },
     async (args) => {
       try {


### PR DESCRIPTION
## Problem

With `@modelcontextprotocol/sdk` v1.29.0 and Zod v4, the `tools/list` MCP request fails with:

```
Cannot read properties of undefined (reading '_zod')
```

This causes Claude Desktop (and other MCP clients) to report **"This connector has no tools available"** for the `vikunja_filters` and `vikunja_templates` tools.

## Root Cause

Zod v4 changed the signature of `z.record()`. In Zod v3, `z.record(valueType)` created a record with string keys and the given value type. In Zod v4, the single argument is treated as the **key** type, leaving `valueType` as `undefined`.

The MCP SDK's `zod-compat.js` calls `isZ4Schema()` on each value in the record's internal definition — when `valueType` is `undefined`, this throws.

## Fix

Use the explicit two-argument form in both affected files:

- `src/tools/filters.ts`: `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`
- `src/tools/templates.ts`: `z.record(z.string())` → `z.record(z.string(), z.string())`

## Testing

Verified by simulating the MCP SDK's `tools/list` processing against all registered tools — all 9 tools now pass before and after the fix.