### PR TITLE
fix: don't extract .message from non-Error throwables

### DIFF
--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -154,12 +154,13 @@ class SecureErrorHandler {
       );
     }
 
-    // For status code errors, convert non-Error objects to "Unknown error"
+    // Only real Error instances contribute their message to the output. Any
+    // other shape (plain strings, objects, null, etc.) becomes "Unknown
+    // error" so that arbitrary upstream API payloads never leak into the
+    // user-visible MCP error surface.
     let message: string;
     if (error instanceof Error) {
       message = error.message;
-    } else if (typeof error === 'string') {
-      message = error;
     } else {
       message = 'Unknown error';
     }
@@ -181,19 +182,13 @@ class SecureErrorHandler {
       message = error.message;
     } else if (typeof error === 'string') {
       message = error;
-    } else if (error === null || error === undefined) {
-      message = 'Unknown error';
-    } else if (typeof error === 'object' && Object.prototype.hasOwnProperty.call(error, 'message')) {
-      // Plain objects with message property
-      message = (error as { message: unknown }).message as string;
-    } else if (typeof error === 'object') {
-      // Plain objects without message property become "Unknown error"
-      message = 'Unknown error';
     } else if (typeof error === 'number' || typeof error === 'boolean') {
-      // Handle primitives explicitly
       message = String(error);
     } else {
-      // Fallback for symbol, bigint, etc.
+      // Plain objects (even those with a message property), null, undefined,
+      // symbols, and bigints all become "Unknown error" here. Extracting
+      // .message from untrusted plain objects would let arbitrary upstream
+      // payloads into user-visible MCP errors.
       message = 'Unknown error';
     }
 

--- a/tests/utils/error-handler.test.ts
+++ b/tests/utils/error-handler.test.ts
@@ -121,10 +121,22 @@ describe('Error Handler Utilities', () => {
     it('should handle non-Error objects', () => {
       const error = { status: 'failed', reason: 'timeout' };
       const result = transformApiError(error, 'Updating task');
-      
+
       expect(result).toBeInstanceOf(MCPError);
       expect(result.code).toBe(ErrorCode.API_ERROR);
       expect(result.message).toBe('Updating task: Unknown error');
+    });
+
+    it('should not extract .message from plain objects', () => {
+      // Plain objects are untrusted: a thrown {message: ...} could be
+      // any upstream payload, not a real Error. Surfacing its .message
+      // would leak that payload into the user-visible MCP error.
+      const error = { message: 'raw upstream payload', extra: 'xyz' };
+      const result = transformApiError(error, 'Fetching projects');
+
+      expect(result).toBeInstanceOf(MCPError);
+      expect(result.code).toBe(ErrorCode.API_ERROR);
+      expect(result.message).toBe('Fetching projects: Unknown error');
     });
 
     it('should handle primitive error values', () => {


### PR DESCRIPTION
## Summary

`SecureErrorHandler` had two paths that could surface raw upstream payloads through to user-visible MCP errors:

1. `handleStatusCode()` passed bare strings through as the error message.
2. `transform()` extracted `.message` from any plain object that happened to have one, regardless of where it came from.

Both let a thrown `{ message: "..." }` payload (or a plain `throw "string"`) reach the MCP error surface unchanged, even though the downstream `.sanitize()` step is built around the assumption that the message came from a real `Error` instance.

This change tightens both methods so only real `Error` instances contribute their `.message`. Any other shape becomes `"Unknown error"`. Strings, numbers, and booleans still pass through `transform()` because the existing test (`should handle primitive error values`) asserts that primitive passthrough is intentional.

## Why

The dropped branches don't have explicit test coverage of their leaky behavior, but they do change the security posture: a thrown plain object with a `message` field looks like an `Error` to the eye but isn't, and treating it as one means upstream payloads (raw API responses, third-party throws, etc.) can land in user-facing errors without going through any of the shape assumptions baked into `.sanitize()`. Treating non-`Error` shapes as untrusted is the simpler and safer default.

## Tests

- All existing tests in `tests/utils/error-handler.test.ts` still pass.
- One new test added: `should not extract .message from plain objects`. This locks in that `transformApiError({ message: "..." })` returns `"Unknown error"` rather than passing the field through.

## Notes

- `handleStatusCode()`'s deleted `typeof error === 'string'` branch had no test asserting passthrough behavior, so removing it doesn't break any contract.
- `transform()`'s `error === null || undefined` and bare `typeof === 'object'` branches collapsed into the final `else` clause (which already returned `"Unknown error"`).
