### PR TITLE
fix: remove HTML encoding and broad SQL keyword matching from sanitizeString

### DIFF
--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -161,14 +161,12 @@ export function sanitizeString(value: string): string {
     /-o-link\s*:/gi,
     /-webkit-binding\s*:/gi,
 
-    // SQL injection patterns
-    /(\b(SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|EXEC|UNION|EXECUTE|TRUNCATE)\b)/gi,
-    /(\b(OR|AND)\s+\d+\s*=\s*\d+)/gi,
-    /(\b(OR|AND)\s+['"].*['"]\s*=\s*['"].*['"])/gi,
+    // SQL injection patterns (narrow: only flag time-delay/blind injection, not plain English words)
     /(\b(WAITFOR\s+DELAY|SLEEP\s*\(|BENCHMARK\s*\(|DBMS_PIPE\.RECEIVE_MESSAGE)\b)/gi,
-    /(--|#|\/\*|\*\/)/gi,  // SQL comments
-    /(\b(INFORMATION_SCHEMA|SYS|MASTER|MSDB|MYSQL|PG_CATALOG)\b)/gi,
     /(\b(XP_|SP_)\w+)/gi,  // SQL Server extended procedures
+
+    // HTML comments (XSS vector regardless of context)
+    /<!--/gi,
 
     // Command injection patterns (more specific to avoid false positives)
     // Removed the broad shell pattern to allow safe HTML tags that should be escaped instead of rejected
@@ -261,17 +259,7 @@ export function sanitizeString(value: string): string {
   normalizedValue = normalizedValue.replace(/\/etc\/passwd/gi, 'etc/passwd');
   normalizedValue = normalizedValue.replace(/c:\\windows\\system32/gi, 'c:/windows/system32');
 
-  // Apply proper HTML escaping (order matters: & must be first)
-  return normalizedValue
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
-    .replace(/\//g, '&#x2F;')
-    .replace(/\\/g, '&#x5C;')  // Escape backslashes too
-    .replace(/`/g, '&#x60;')   // Escape backticks
-    .replace(/=/g, '&#x3D;')   // Escape equals signs in attributes
+  return normalizedValue;
 }
 
 /**

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -29,12 +29,12 @@ describe('Security Validation Utilities', () => {
       expect(result).toBe('This is a valid string');
     });
 
-    it('should escape HTML special characters (when not XSS)', () => {
+    it('should pass through safe strings without HTML encoding (output is JSON API, not HTML)', () => {
       const testCases = [
-        { input: 'Hello <world>', expected: 'Hello &lt;world&gt;' },
-        { input: 'Test "quoted" string', expected: 'Test &quot;quoted&quot; string' },
-        { input: "Test 'single' quotes", expected: 'Test &#x27;single&#x27; quotes' },
-        { input: 'path/to/file', expected: 'path&#x2F;to&#x2F;file' }
+        { input: 'Hello <world>', expected: 'Hello <world>' },
+        { input: 'Test "quoted" string', expected: 'Test "quoted" string' },
+        { input: "Test 'single' quotes", expected: "Test 'single' quotes" },
+        { input: 'path/to/file', expected: 'path/to/file' }
       ];
 
       testCases.forEach(({ input, expected }) => {
@@ -72,7 +72,7 @@ describe('Security Validation Utilities', () => {
         '<meta>',
         '<style>',
         '<svg>',
-        '<!-- malicious script -->',
+        '<!-- malicious script -->', // HTML comments are blocked
         'expression(alert(1))',
         'eval("malicious")',
         'Function("malicious")',
@@ -729,13 +729,11 @@ describe('Security Validation Utilities', () => {
       });
     });
 
-    it('should escape safe HTML content', () => {
-      // Test that safe HTML tags are escaped rather than stripped
+    it('should pass through safe HTML content without encoding (output is JSON API, not HTML)', () => {
+      // Safe formatting tags are not XSS vectors and should pass through unchanged
       const safeInput = '<b>Bold text</b><em>Emphasis</em>';
       const result = sanitizeString(safeInput);
-      // HTML entities should be escaped
-      expect(result).toContain('&lt;b&gt;');
-      expect(result).toContain('&lt;em&gt;');
+      expect(result).toBe('<b>Bold text</b><em>Emphasis</em>');
       expect(typeof result).toBe('string');
     });
   });


### PR DESCRIPTION
## Problem

`sanitizeString()` in `src/utils/validation.ts` was HTML-encoding its output before the caller sent it to the Vikunja JSON API. This corrupted any string containing apostrophes, slashes, angle brackets, quotes, or ampersands:

- `"Jun's suffix"` → stored as `"Jun&#x27;s suffix"`
- `"Create/Update"` → stored as `"Create&#x2F;Update"`

HTML encoding belongs at **render time** (browser output), not at the API call boundary. The Vikunja API receives JSON and stores the raw string — it doesn't interpret HTML entities, so they were written verbatim to the database.

Additionally, the SQL injection blocklist matched on common English words (`CREATE`, `UPDATE`, `SELECT`, `DELETE`, `DROP`, etc.), causing legitimate task titles like *"Create Greenlight rewards system"* to be rejected as dangerous input.

## Fix

- **Removed the HTML escape block** — the final `.replace()` chain converting `'` → `&#x27;`, `/` → `&#x2F;`, etc. `sanitizeString` now returns the normalized value directly.
- **Replaced the broad SQL keyword regex** with narrow time-delay/blind injection patterns only (`WAITFOR DELAY`, `SLEEP()`, `BENCHMARK()`, `DBMS_PIPE.RECEIVE_MESSAGE`) and SQL Server stored procedure prefixes (`XP_`/`SP_`). These have no legitimate use in natural language and are genuine injection vectors.
- **Added a targeted `<!--` pattern** to preserve detection of HTML comment injection, which was previously caught as a side effect of the `--` SQL comment pattern that was removed.
- Updated validation tests to assert passthrough behavior rather than HTML encoding.

## Testing

All 73 tests in `tests/utils/validation.test.ts` pass. Three tests were updated to assert correct passthrough behavior (previously asserting the now-removed HTML encoding).