### PR TITLE
fix: add post-assignment verification to detect silent API failures

### DIFF
--- a/tests/tools/tasks/assignees.test.ts
+++ b/tests/tools/tasks/assignees.test.ts
@@ -59,6 +59,27 @@ describe('Assignee operations', () => {
       expect(markdown).toContain('Users assigned to task successfully');
     });
 
+    it('should warn when assignees are not persisted (silent API failure)', async () => {
+      // Simulate the Vikunja API silently not persisting assignees
+      const mockTaskNoAssignees = {
+        id: 123,
+        title: 'Test Task',
+        assignees: [], // API returned success but assignees didn't persist
+      };
+
+      mockClient.tasks.bulkAssignUsersToTask.mockResolvedValue({});
+      mockClient.tasks.getTask.mockResolvedValue(mockTaskNoAssignees);
+
+      const result = await assignUsers({
+        id: 123,
+        assignees: [1, 2],
+      });
+
+      const markdown = result.content[0].text;
+      expect(markdown).toContain('not persisted');
+      expect(markdown).toContain('JWT authentication');
+    });
+
     it('should throw error when task id is missing', async () => {
       await expect(assignUsers({ assignees: [1, 2] })).rejects.toThrow(
         'Task id is required for assign operation'


### PR DESCRIPTION
## Problem

The Vikunja API has a known limitation (relates to #15) where bulk assignee operations return HTTP 200 but silently fail to persist the assignees when using API token authentication. The caller has no way to know the assignment didn't stick.

## Fix

Adds a post-operation verification step that re-fetches the task and compares the persisted assignee IDs against the requested IDs:

- **`AssigneeOperationsService.verifyAssignees()`** — re-fetches the task after assignment and returns any IDs that weren't persisted. If the verification fetch itself fails, it returns empty (fail-open — don't block the caller).
- **`assignUsers()`** — calls verify after assign; if any IDs are missing, sets `success: false` and surfaces a message explaining the API limitation and suggesting JWT auth as a workaround.
- **`createTask()`** — same verification when assignees are passed at creation time; includes a warning in the response message if persistence failed.

## Testing

Added a test that simulates the silent failure case: `bulkAssignUsersToTask` resolves successfully but `getTask` returns the task with no assignees. Asserts that the response contains the persistence warning and JWT suggestion.