### PR TITLE
Add Kanban bucket operations (set-bucket, list-buckets)

### DIFF
--- a/src/tools/projects/buckets.ts
+++ b/src/tools/projects/buckets.ts
@@ -1,0 +1,95 @@
+/**
+ * Project Kanban bucket operations
+ *
+ * Implements `list-buckets`, which returns the buckets (columns) of a
+ * project's Kanban view. This lets callers resolve a bucket by name (e.g.
+ * "Doing") instead of hard-coding numeric bucket ids.
+ *
+ * node-vikunja does not expose the Kanban view endpoints, so this calls the
+ * Vikunja REST API directly via the shared `vikunja-rest` helper.
+ */
+
+import type { AuthManager } from '../../auth/AuthManager';
+import { MCPError, ErrorCode } from '../../types';
+import { validateId } from '../../utils/validation';
+import { createStandardResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../utils/vikunja-rest';
+
+export interface ListBucketsArgs {
+  /** Project whose Kanban buckets should be listed. */
+  id?: number;
+  /** Optional Kanban view id. Auto-resolved from the project when omitted. */
+  viewId?: number;
+  /** Session id for response tracking. */
+  sessionId?: string;
+}
+
+interface VikunjaBucket {
+  id: number;
+  title: string;
+  project_view_id?: number;
+  position?: number;
+  limit?: number;
+  is_done_bucket?: boolean;
+}
+
+/**
+ * Lists the Kanban buckets of a project.
+ *
+ * @param args - Project id and optional view id
+ * @param authManager - Active auth manager holding session credentials
+ * @returns MCP response containing the project's Kanban buckets
+ */
+export async function listBuckets(
+  args: ListBucketsArgs,
+  authManager: AuthManager,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  if (!args.id) {
+    throw new MCPError(
+      ErrorCode.VALIDATION_ERROR,
+      'Project id is required for list-buckets operation',
+    );
+  }
+  validateId(args.id, 'id');
+  if (args.viewId !== undefined) validateId(args.viewId, 'viewId');
+
+  const viewId =
+    args.viewId !== undefined ? args.viewId : await resolveKanbanViewId(authManager, args.id);
+
+  const buckets = await vikunjaRestRequest<VikunjaBucket[]>(
+    authManager,
+    'GET',
+    `/projects/${args.id}/views/${viewId}/buckets`,
+  );
+  const bucketList = Array.isArray(buckets) ? buckets : [];
+
+  const response = createStandardResponse(
+    'list-buckets',
+    `Found ${bucketList.length} buckets in the Kanban view of project ${args.id}`,
+    {
+      projectId: args.id,
+      viewId,
+      buckets: bucketList.map((bucket) => ({
+        id: bucket.id,
+        title: bucket.title,
+        position: bucket.position,
+        limit: bucket.limit,
+        isDoneBucket: bucket.is_done_bucket ?? false,
+      })),
+    },
+    {
+      timestamp: new Date().toISOString(),
+      count: bucketList.length,
+    },
+    args.sessionId,
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: formatAorpAsMarkdown(response),
+      },
+    ],
+  };
+}

--- a/src/tools/projects/index.ts
+++ b/src/tools/projects/index.ts
@@ -53,6 +53,8 @@ import {
   type AuthShareArgs
 } from './sharing';
 
+import { listBuckets, type ListBucketsArgs } from './buckets';
+
 /**
  * Legacy single-tool interface for backward compatibility
  * Registers a single tool with all subcommands like the original implementation
@@ -64,11 +66,12 @@ export function registerProjectsTool(
 ): void {
   server.tool(
     'vikunja_projects',
-    'Manage projects with full CRUD operations, hierarchy management, and sharing capabilities',
+    'Manage projects with full CRUD operations, hierarchy management, sharing capabilities, and Kanban bucket listing',
     {
       subcommand: z.enum(['list', 'get', 'create', 'update', 'delete', 'archive', 'unarchive',
         'get-children', 'get-tree', 'get-breadcrumb', 'move',
-        'create-share', 'list-shares', 'get-share', 'delete-share', 'auth-share'
+        'create-share', 'list-shares', 'get-share', 'delete-share', 'auth-share',
+        'list-buckets'
       ]),
       // CRUD arguments
       id: z.number().positive().optional(),
@@ -83,6 +86,8 @@ export function registerProjectsTool(
       // Hierarchy arguments
       maxDepth: z.number().min(1).max(20).optional(),
       includeArchived: z.boolean().optional(),
+      // Kanban bucket arguments (list-buckets subcommand)
+      viewId: z.number().positive().optional(),
       // Sharing arguments
       projectId: z.number().positive().optional(),
       shareId: z.string().optional(),
@@ -218,6 +223,14 @@ export function registerProjectsTool(
             if (args.password !== undefined) authShareArgs.password = args.password;
             return await authProjectShare(authShareArgs);
           }
+
+          // Kanban bucket operations
+          case 'list-buckets':
+            if (!args.id) {
+              throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Project ID is required for list-buckets operation');
+            }
+            validateId(args.id, 'id');
+            return await listBuckets(args as ListBucketsArgs, authManager);
 
           default:
             throw new MCPError(ErrorCode.VALIDATION_ERROR, `Unknown subcommand: ${String(args.subcommand)}`);

--- a/src/tools/projects/index.ts
+++ b/src/tools/projects/index.ts
@@ -86,8 +86,10 @@ export function registerProjectsTool(
       // Hierarchy arguments
       maxDepth: z.number().min(1).max(20).optional(),
       includeArchived: z.boolean().optional(),
-      // Kanban bucket arguments (list-buckets subcommand)
-      viewId: z.number().positive().optional(),
+      // Kanban bucket arguments (list-buckets subcommand).
+      // z.coerce tolerates MCP clients whose cached tool schema predates
+      // this param and therefore send it as a string over JSON-RPC.
+      viewId: z.coerce.number().positive().optional(),
       // Sharing arguments
       projectId: z.number().positive().optional(),
       shareId: z.string().optional(),

--- a/src/tools/tasks/buckets.ts
+++ b/src/tools/tasks/buckets.ts
@@ -1,0 +1,121 @@
+/**
+ * Task Kanban bucket operations
+ *
+ * Implements `set-bucket`, which moves a task into a Kanban bucket (column)
+ * of its project's Kanban view. This is the operation behind a "move card to
+ * the Doing column" workflow.
+ *
+ * node-vikunja does not expose the Kanban view endpoints, so this calls the
+ * Vikunja REST API directly via the shared `vikunja-rest` helper.
+ */
+
+import type { AuthManager } from '../../auth/AuthManager';
+import { MCPError, ErrorCode } from '../../types';
+import { validateId } from '../../utils/validation';
+import { createStandardResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../utils/vikunja-rest';
+
+export interface SetTaskBucketArgs {
+  /** Id of the task to move. */
+  id?: number;
+  /** Id of the destination Kanban bucket. */
+  bucketId?: number;
+  /** Optional Kanban view id. Auto-resolved from the project when omitted. */
+  viewId?: number;
+  /** Optional project id. Auto-resolved from the task when omitted. */
+  projectId?: number;
+  /** Session id for response tracking. */
+  sessionId?: string;
+}
+
+interface VikunjaTaskSummary {
+  id: number;
+  project_id: number;
+  title?: string;
+}
+
+/**
+ * Moves a task into a Kanban bucket.
+ *
+ * Resolution order when optional ids are omitted:
+ *  - projectId: fetched from the task itself
+ *  - viewId: resolved to the project's Kanban view
+ *
+ * @param args - Task id, destination bucket id, and optional view/project ids
+ * @param authManager - Active auth manager holding session credentials
+ * @returns MCP response describing the move
+ */
+export async function setTaskBucket(
+  args: SetTaskBucketArgs,
+  authManager: AuthManager,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  if (!args.id) {
+    throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Task id is required for set-bucket operation');
+  }
+  if (args.bucketId === undefined || args.bucketId === null) {
+    throw new MCPError(
+      ErrorCode.VALIDATION_ERROR,
+      'bucketId is required for set-bucket operation',
+    );
+  }
+  validateId(args.id, 'id');
+  validateId(args.bucketId, 'bucketId');
+  if (args.viewId !== undefined) validateId(args.viewId, 'viewId');
+  if (args.projectId !== undefined) validateId(args.projectId, 'projectId');
+
+  // Resolve the project id from the task when the caller did not supply it.
+  let projectId = args.projectId;
+  if (projectId === undefined) {
+    const task = await vikunjaRestRequest<VikunjaTaskSummary>(
+      authManager,
+      'GET',
+      `/tasks/${args.id}`,
+    );
+    if (!task || typeof task.project_id !== 'number') {
+      throw new MCPError(
+        ErrorCode.NOT_FOUND,
+        `Could not resolve the project of task ${args.id}`,
+      );
+    }
+    projectId = task.project_id;
+  }
+
+  // Resolve the Kanban view id when the caller did not supply it.
+  const viewId =
+    args.viewId !== undefined ? args.viewId : await resolveKanbanViewId(authManager, projectId);
+
+  // Place the task into the bucket. Vikunja's bucket-task endpoint expects the
+  // TaskBucket payload; bucket_id is also part of the URL but is sent in the
+  // body as the API model requires it.
+  await vikunjaRestRequest(
+    authManager,
+    'POST',
+    `/projects/${projectId}/views/${viewId}/buckets/${args.bucketId}/tasks`,
+    { task_id: args.id, bucket_id: args.bucketId },
+  );
+
+  const response = createStandardResponse(
+    'set-task-bucket',
+    `Task ${args.id} moved to bucket ${args.bucketId}`,
+    {
+      taskId: args.id,
+      bucketId: args.bucketId,
+      viewId,
+      projectId,
+    },
+    {
+      timestamp: new Date().toISOString(),
+      affectedFields: ['bucket_id'],
+    },
+    args.sessionId,
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: formatAorpAsMarkdown(response),
+      },
+    ],
+  };
+}

--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -100,6 +100,15 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
 
     try {
       if (!args.field) throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Field required');
+
+      // The native Vikunja bulk endpoint truncates fields it does not receive
+      // (description, priority, ...) when moving tasks across projects, which
+      // silently corrupts task data. Route project_id moves through the
+      // field-preserving per-task path (getTask + merge + updateTask) instead.
+      if (args.field === 'project_id') {
+        return await updateWithFallback();
+      }
+
       const bulkOp = { task_ids: taskIds, field: args.field, value: args.value };
       if (args.field === 'repeat_mode' && typeof args.value === 'string') {
         bulkOp.value = REPEAT_MODE_MAP[args.value] ?? args.value;

--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -18,6 +18,7 @@ export interface UpdateTaskArgs {
   id?: number;
   title?: string;
   description?: string;
+  projectId?: number;
   dueDate?: string;
   priority?: number;
   done?: boolean;
@@ -132,6 +133,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   const previousState: Record<string, unknown> = {};
   if (currentTask.title !== undefined) previousState.title = currentTask.title;
   if (currentTask.description !== undefined) previousState.description = currentTask.description;
+  if (currentTask.project_id !== undefined) previousState.project_id = currentTask.project_id;
   if (currentTask.due_date !== undefined) previousState.due_date = currentTask.due_date;
   if (currentTask.priority !== undefined) previousState.priority = currentTask.priority;
   if (currentTask.done !== undefined) previousState.done = currentTask.done;
@@ -143,6 +145,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
 
   if (args.title !== undefined && args.title !== currentTask.title) affectedFields.push('title');
   if (args.description !== undefined && args.description !== currentTask.description) affectedFields.push('description');
+  if (args.projectId !== undefined && args.projectId !== currentTask.project_id) affectedFields.push('projectId');
   if (args.dueDate !== undefined && args.dueDate !== currentTask.due_date) affectedFields.push('dueDate');
   if (args.priority !== undefined && args.priority !== currentTask.priority) affectedFields.push('priority');
   if (args.done !== undefined && args.done !== currentTask.done) affectedFields.push('done');
@@ -168,6 +171,7 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
     // Override with any provided updates
     ...(args.title !== undefined && { title: args.title }),
     ...(args.description !== undefined && { description: args.description }),
+    ...(args.projectId !== undefined && { project_id: args.projectId }),
     ...(args.dueDate !== undefined && { due_date: args.dueDate }),
     ...(args.priority !== undefined && { priority: args.priority }),
     ...(args.done !== undefined && { done: args.done }),

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -157,9 +157,11 @@ export function registerTasksTool(
       priority: z.number().min(0).max(5).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
-      // Kanban bucket fields (set-bucket subcommand)
-      bucketId: z.number().optional(),
-      viewId: z.number().optional(),
+      // Kanban bucket fields (set-bucket subcommand).
+      // z.coerce tolerates MCP clients whose cached tool schema predates
+      // these params and therefore send them as strings over JSON-RPC.
+      bucketId: z.coerce.number().optional(),
+      viewId: z.coerce.number().optional(),
       // Recurring task fields
       repeatAfter: z.number().min(0).optional(),
       repeatMode: z.enum(['day', 'week', 'month', 'year']).optional(),

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -25,6 +25,7 @@ import { assignUsers, unassignUsers, listAssignees } from './assignees';
 import { handleComment } from './comments';
 import { addReminder, removeReminder, listReminders } from './reminders';
 import { applyLabels, removeLabels, listTaskLabels } from './labels';
+import { setTaskBucket } from './buckets';
 
 
 /**
@@ -121,7 +122,7 @@ export function registerTasksTool(
 ): void {
   server.tool(
     'vikunja_tasks',
-    'Manage tasks with comprehensive operations (create, update, delete, list, assign, attach files, comment, bulk operations)',
+    'Manage tasks with comprehensive operations (create, update, delete, list, assign, attach files, comment, bulk operations, set Kanban bucket)',
     {
       subcommand: z.enum([
         'create',
@@ -146,6 +147,7 @@ export function registerTasksTool(
         'apply-label',
         'remove-label',
         'list-labels',
+        'set-bucket',
       ]),
       // Task creation/update fields
       title: z.string().optional(),
@@ -155,6 +157,9 @@ export function registerTasksTool(
       priority: z.number().min(0).max(5).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
+      // Kanban bucket fields (set-bucket subcommand)
+      bucketId: z.number().optional(),
+      viewId: z.number().optional(),
       // Recurring task fields
       repeatAfter: z.number().min(0).optional(),
       repeatMode: z.enum(['day', 'week', 'month', 'year']).optional(),
@@ -286,6 +291,9 @@ export function registerTasksTool(
 
           case 'list-labels':
             return listTaskLabels(args as Parameters<typeof listTaskLabels>[0]);
+
+          case 'set-bucket':
+            return setTaskBucket(args as Parameters<typeof setTaskBucket>[0], authManager);
 
           default:
             throw new MCPError(

--- a/src/utils/vikunja-rest.ts
+++ b/src/utils/vikunja-rest.ts
@@ -1,0 +1,125 @@
+/**
+ * Direct REST helper for Vikunja API endpoints not covered by node-vikunja.
+ *
+ * node-vikunja (the typed client this MCP server wraps) does not expose the
+ * Kanban view endpoints — listing the buckets of a view, or placing a task
+ * into a bucket. Those operations therefore call the Vikunja REST API
+ * directly, reusing the credentials of the active authenticated session.
+ */
+
+import type { AuthManager } from '../auth/AuthManager';
+import { MCPError, ErrorCode } from '../types';
+
+/**
+ * Performs an authenticated request against the Vikunja REST API.
+ *
+ * @param authManager - Active auth manager holding the session credentials
+ * @param method - HTTP method
+ * @param path - API path relative to the configured apiUrl, must start with '/'
+ *               (e.g. '/projects/4/views')
+ * @param body - Optional value serialized as a JSON request body
+ * @returns The parsed JSON response, or null when the response has no body
+ * @throws MCPError when the network call fails or the response is not OK
+ */
+export async function vikunjaRestRequest<T = unknown>(
+  authManager: AuthManager,
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const session = authManager.getSession();
+  // session.apiUrl may or may not already include the `/api/v1` prefix
+  // depending on how VIKUNJA_URL was configured; normalize so REST paths
+  // (which are relative to the API root) always resolve correctly.
+  const trimmed = session.apiUrl.replace(/\/+$/, '');
+  const baseUrl = /\/api\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/api/v1`;
+  const url = `${baseUrl}${path}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${session.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (error) {
+    throw new MCPError(
+      ErrorCode.API_ERROR,
+      `Vikunja REST request failed (${method} ${path}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (!response.ok) {
+    let detail = '';
+    try {
+      detail = (await response.text()).slice(0, 500);
+    } catch {
+      // Body could not be read — fall back to the status line only.
+    }
+    throw new MCPError(
+      ErrorCode.API_ERROR,
+      `Vikunja REST request failed (${method} ${path}): HTTP ${response.status} ${
+        response.statusText
+      }${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return null as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    // A 2xx response with a non-JSON body (rare) is treated as an empty result.
+    return null as T;
+  }
+}
+
+/**
+ * Minimal shape of a Vikunja project view as returned by `/projects/{id}/views`.
+ */
+export interface VikunjaView {
+  id: number;
+  title: string;
+  project_id: number;
+  view_kind: string;
+}
+
+/**
+ * Resolves the Kanban view id for a project.
+ *
+ * Vikunja projects have several views (list, gantt, table, kanban). Bucket
+ * operations only make sense against the Kanban view, so callers that do not
+ * already know the view id can use this to find it.
+ *
+ * @param authManager - Active auth manager
+ * @param projectId - Project whose Kanban view should be resolved
+ * @returns The numeric id of the project's Kanban view
+ * @throws MCPError when the project has no Kanban view
+ */
+export async function resolveKanbanViewId(
+  authManager: AuthManager,
+  projectId: number,
+): Promise<number> {
+  const views = await vikunjaRestRequest<VikunjaView[]>(
+    authManager,
+    'GET',
+    `/projects/${projectId}/views`,
+  );
+  const kanban = Array.isArray(views)
+    ? views.find((view) => view.view_kind === 'kanban')
+    : undefined;
+  if (!kanban) {
+    throw new MCPError(
+      ErrorCode.NOT_FOUND,
+      `Project ${projectId} has no Kanban view, so it has no buckets`,
+    );
+  }
+  return kanban.id;
+}

--- a/tests/tools/projects/buckets.test.ts
+++ b/tests/tools/projects/buckets.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the project Kanban bucket listing operation (`list-buckets`).
+ *
+ * Covers id validation, view auto-resolution vs an explicit viewId, empty and
+ * non-array bucket responses, optional bucket fields, and error propagation.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../../src/auth/AuthManager';
+import { listBuckets } from '../../../src/tools/projects/buckets';
+import { MCPError, ErrorCode } from '../../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** Minimal Response-like object for the REST helper. */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+}): Response {
+  const { ok = true, status = 200, statusText = 'OK', text = '' } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+/** A views payload containing a Kanban view (id 11). */
+const kanbanViews = JSON.stringify([
+  { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+  { id: 11, title: 'Kanban', project_id: 5, view_kind: 'kanban' },
+]);
+
+describe('listBuckets', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('validation', () => {
+    it('throws a VALIDATION_ERROR when the project id is missing', async () => {
+      await expect(listBuckets({}, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'Project id is required for list-buckets operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when the project id is zero (falsy)', async () => {
+      await expect(listBuckets({ id: 0 }, authManager)).rejects.toThrow(
+        'Project id is required for list-buckets operation',
+      );
+    });
+
+    it('throws when the project id is not a positive integer', async () => {
+      await expect(listBuckets({ id: -3 }, authManager)).rejects.toThrow(
+        'id must be a positive integer',
+      );
+    });
+
+    it('throws when an explicit viewId is invalid', async () => {
+      await expect(listBuckets({ id: 5, viewId: 0 }, authManager)).rejects.toThrow(
+        'viewId must be a positive integer',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('view resolution', () => {
+    it('resolves the Kanban view id when viewId is omitted', async () => {
+      // 1) GET /projects/:id/views  2) GET buckets
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(
+          mockResponse({
+            text: JSON.stringify([
+              {
+                id: 100,
+                title: 'Backlog',
+                project_view_id: 11,
+                position: 0,
+                limit: 0,
+                is_done_bucket: false,
+              },
+              {
+                id: 101,
+                title: 'Done',
+                project_view_id: 11,
+                position: 1,
+                limit: 5,
+                is_done_bucket: true,
+              },
+            ]),
+          }),
+        );
+
+      const result = await listBuckets({ id: 5 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[1]).toBe('https://vikunja.test/api/v1/projects/5/views/11/buckets');
+
+      const text = result.content[0].text;
+      expect(text).toContain('Found 2 buckets in the Kanban view of project 5');
+      expect(text).toContain('Backlog');
+      expect(text).toContain('Done');
+    });
+
+    it('uses an explicit viewId without resolving the Kanban view', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([{ id: 100, title: 'Backlog' }]),
+        }),
+      );
+
+      const result = await listBuckets({ id: 5, viewId: 42 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/5/views/42/buckets');
+      expect(result.content[0].text).toContain('Found 1 buckets');
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([
+            { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+          ]),
+        }),
+      );
+
+      await expect(listBuckets({ id: 5 }, authManager)).rejects.toThrow(
+        'Project 5 has no Kanban view, so it has no buckets',
+      );
+    });
+  });
+
+  describe('bucket response handling', () => {
+    it('returns an empty bucket list when the API returns an empty array', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      expect(result.content[0].text).toContain('Found 0 buckets');
+    });
+
+    it('treats a non-array bucket response as an empty list', async () => {
+      // An empty 2xx body resolves to null inside vikunjaRestRequest.
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      expect(result.content[0].text).toContain('Found 0 buckets');
+    });
+
+    it('defaults isDoneBucket to false when the field is absent', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([{ id: 100, title: 'Backlog' }]),
+        }),
+      );
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      const text = result.content[0].text;
+      expect(text).toContain('Found 1 buckets');
+      expect(text).toContain('"isDoneBucket": false');
+    });
+
+    it('passes a session id through to the response', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      const result = await listBuckets(
+        { id: 5, viewId: 11, sessionId: 'sess-9' },
+        authManager,
+      );
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Success');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates an HTTP error from the buckets request', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: 'view does not exist',
+        }),
+      );
+
+      await expect(
+        listBuckets({ id: 5, viewId: 11 }, authManager),
+      ).rejects.toThrow(MCPError);
+    });
+
+    it('propagates a network error raised while resolving the view', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('offline'));
+
+      await expect(listBuckets({ id: 5 }, authManager)).rejects.toThrow(
+        'Vikunja REST request failed (GET /projects/5/views): offline',
+      );
+    });
+  });
+});

--- a/tests/tools/tasks/buckets.test.ts
+++ b/tests/tools/tasks/buckets.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the task Kanban bucket operation (`set-bucket`).
+ *
+ * Covers validation of required/optional ids, project and view auto-resolution,
+ * explicit project/view ids, and propagation of REST errors.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../../src/auth/AuthManager';
+import { setTaskBucket } from '../../../src/tools/tasks/buckets';
+import { MCPError, ErrorCode } from '../../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** Minimal Response-like object for the REST helper. */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+}): Response {
+  const { ok = true, status = 200, statusText = 'OK', text = '' } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+/** A views payload containing a Kanban view (id 11). */
+const kanbanViews = JSON.stringify([
+  { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+  { id: 11, title: 'Kanban', project_id: 5, view_kind: 'kanban' },
+]);
+
+describe('setTaskBucket', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('validation', () => {
+    it('throws a VALIDATION_ERROR when the task id is missing', async () => {
+      await expect(setTaskBucket({ bucketId: 3 }, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'Task id is required for set-bucket operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when the task id is zero (falsy)', async () => {
+      await expect(
+        setTaskBucket({ id: 0, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Task id is required for set-bucket operation');
+    });
+
+    it('throws a VALIDATION_ERROR when bucketId is undefined', async () => {
+      await expect(setTaskBucket({ id: 1 }, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'bucketId is required for set-bucket operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when bucketId is null', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: null as unknown as number }, authManager),
+      ).rejects.toThrow('bucketId is required for set-bucket operation');
+    });
+
+    it('treats a bucketId of 0 as provided and validates it as an id', async () => {
+      // bucketId 0 passes the undefined/null guard but fails validateId.
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 0 }, authManager),
+      ).rejects.toThrow('bucketId must be a positive integer');
+    });
+
+    it('throws when the task id is not a positive integer', async () => {
+      await expect(
+        setTaskBucket({ id: -2, bucketId: 3 }, authManager),
+      ).rejects.toThrow('id must be a positive integer');
+    });
+
+    it('throws when an explicit viewId is invalid', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, viewId: -1 }, authManager),
+      ).rejects.toThrow('viewId must be a positive integer');
+    });
+
+    it('throws when an explicit projectId is invalid', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, projectId: 0 }, authManager),
+      ).rejects.toThrow('projectId must be a positive integer');
+    });
+  });
+
+  describe('project and view resolution', () => {
+    it('resolves project and view ids from the API when both are omitted', async () => {
+      // 1) GET /tasks/:id  2) GET /projects/:id/views  3) POST bucket task
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 5, title: 'T' }) }),
+        )
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await setTaskBucket({ id: 1, bucketId: 3 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/tasks/1');
+      expect(urls[1]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[2]).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+
+      // The POST body carries the TaskBucket payload.
+      const [, postInit] = mockFetch.mock.calls[2] as [string, RequestInit];
+      expect(postInit.method).toBe('POST');
+      expect(postInit.body).toBe(JSON.stringify({ task_id: 1, bucket_id: 3 }));
+
+      const text = result.content[0].text;
+      expect(text).toContain('Task 1 moved to bucket 3');
+      expect(text).toContain('Success');
+    });
+
+    it('does not fetch the task when projectId is supplied explicitly', async () => {
+      // 1) GET /projects/:id/views  2) POST bucket task
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await setTaskBucket({ id: 1, bucketId: 3, projectId: 5 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[1]).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+    });
+
+    it('does not resolve the view when viewId is supplied explicitly', async () => {
+      // projectId omitted -> GET /tasks/:id, then POST (no views lookup)
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 8 }) }),
+        )
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await setTaskBucket({ id: 1, bucketId: 3, viewId: 22 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/tasks/1');
+      expect(urls[1]).toBe(
+        'https://vikunja.test/api/v1/projects/8/views/22/buckets/3/tasks',
+      );
+    });
+
+    it('issues only the bucket POST when both projectId and viewId are supplied', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await setTaskBucket(
+        { id: 1, bucketId: 3, projectId: 5, viewId: 11, sessionId: 'sess-1' },
+        authManager,
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+      expect(result.content[0].type).toBe('text');
+    });
+
+    it('throws NOT_FOUND when the task lookup returns no body', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow(
+        new MCPError(
+          ErrorCode.NOT_FOUND,
+          'Could not resolve the project of task 1',
+        ),
+      );
+    });
+
+    it('throws NOT_FOUND when the task has no numeric project_id', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ text: JSON.stringify({ id: 1, project_id: 'oops' }) }),
+      );
+
+      try {
+        await setTaskBucket({ id: 1, bucketId: 3 }, authManager);
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.NOT_FOUND);
+      }
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 5 }) }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            text: JSON.stringify([
+              { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+            ]),
+          }),
+        );
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Project 5 has no Kanban view, so it has no buckets');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates an HTTP error from the bucket POST', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: 'invalid bucket',
+        }),
+      );
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, projectId: 5, viewId: 11 }, authManager),
+      ).rejects.toThrow(MCPError);
+    });
+
+    it('propagates a network error raised while resolving the task', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Vikunja REST request failed (GET /tasks/1): network down');
+    });
+  });
+});

--- a/tests/utils/vikunja-rest.test.ts
+++ b/tests/utils/vikunja-rest.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the direct Vikunja REST helper.
+ *
+ * Covers vikunjaRestRequest (URL normalization, body handling, HTTP errors,
+ * network errors, empty/non-JSON bodies) and resolveKanbanViewId.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../src/auth/AuthManager';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../src/utils/vikunja-rest';
+import { MCPError, ErrorCode } from '../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/**
+ * Builds a minimal Response-like object good enough for vikunjaRestRequest,
+ * which only reads `.ok`, `.status`, `.statusText` and `.text()`.
+ */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+  textThrows?: boolean;
+}): Response {
+  const {
+    ok = true,
+    status = 200,
+    statusText = 'OK',
+    text = '',
+    textThrows = false,
+  } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: textThrows
+      ? jest.fn(async () => {
+          throw new Error('stream read error');
+        })
+      : jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+describe('vikunja-rest helper', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('vikunjaRestRequest', () => {
+    it('performs a GET request and parses the JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify({ id: 7 }) }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/tasks/7');
+
+      expect(result).toEqual({ id: 7 });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      // apiUrl had no /api/v1 prefix, so it must have been appended.
+      expect(url).toBe('https://vikunja.test/api/v1/tasks/7');
+      expect(init.method).toBe('GET');
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        'Bearer tk_test-token',
+      );
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+        'application/json',
+      );
+      // No body when none is supplied.
+      expect(init.body).toBeUndefined();
+    });
+
+    it('serializes the body as JSON when one is provided', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await vikunjaRestRequest(authManager, 'POST', '/things', { a: 1 });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ a: 1 }));
+    });
+
+    it('does not normalize an apiUrl that already includes the /api/v1 prefix', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/api/v1', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects/4/views');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/4/views');
+    });
+
+    it('strips a trailing slash from the apiUrl before building the URL', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects');
+    });
+
+    it('recognizes an /api/v2 versioned root', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/api/v2', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v2/projects');
+    });
+
+    it('returns null when the response body is empty', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/empty');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the response body is not valid JSON', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: 'not json at all' }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/weird');
+
+      expect(result).toBeNull();
+    });
+
+    it('throws an MCPError when fetch rejects (network error)', async () => {
+      // Persistent rejection: this test makes two assertion calls.
+      mockFetch.mockRejectedValue(new Error('connection refused'));
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(MCPError);
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): connection refused',
+      );
+    });
+
+    it('includes the error code API_ERROR on network failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('boom'));
+
+      try {
+        await vikunjaRestRequest(authManager, 'GET', '/tasks/1');
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.API_ERROR);
+      }
+    });
+
+    it('stringifies a non-Error rejection value', async () => {
+      mockFetch.mockRejectedValueOnce('plain string failure');
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): plain string failure',
+      );
+    });
+
+    it('throws an MCPError with the response detail when the response is not OK', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: 'task does not exist',
+        }),
+      );
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/999'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/999): HTTP 404 Not Found — task does not exist',
+      );
+    });
+
+    it('omits the detail suffix when the error body is empty', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          text: '',
+        }),
+      );
+
+      try {
+        await vikunjaRestRequest(authManager, 'POST', '/things');
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect((error as MCPError).message).toBe(
+          'Vikunja REST request failed (POST /things): HTTP 500 Internal Server Error',
+        );
+      }
+    });
+
+    it('truncates an oversized error body to 500 characters', async () => {
+      const longBody = 'x'.repeat(2000);
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: longBody,
+        }),
+      );
+
+      try {
+        await vikunjaRestRequest(authManager, 'GET', '/tasks/1');
+        throw new Error('should have thrown');
+      } catch (error) {
+        const message = (error as MCPError).message;
+        // 500 chars of 'x' should be present, but not the full 2000.
+        expect(message).toContain('x'.repeat(500));
+        expect(message).not.toContain('x'.repeat(501));
+      }
+    });
+
+    it('falls back to the status line when the error body cannot be read', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 502,
+          statusText: 'Bad Gateway',
+          textThrows: true,
+        }),
+      );
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): HTTP 502 Bad Gateway',
+      );
+    });
+  });
+
+  describe('resolveKanbanViewId', () => {
+    it('returns the id of the Kanban view when one exists', async () => {
+      const views = [
+        { id: 10, title: 'List', project_id: 4, view_kind: 'list' },
+        { id: 11, title: 'Kanban', project_id: 4, view_kind: 'kanban' },
+        { id: 12, title: 'Gantt', project_id: 4, view_kind: 'gantt' },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify(views) }));
+
+      const viewId = await resolveKanbanViewId(authManager, 4);
+
+      expect(viewId).toBe(11);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/4/views');
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      const views = [{ id: 10, title: 'List', project_id: 4, view_kind: 'list' }];
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify(views) }));
+
+      await expect(resolveKanbanViewId(authManager, 4)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.NOT_FOUND,
+          'Project 4 has no Kanban view, so it has no buckets',
+        ),
+      );
+    });
+
+    it('throws NOT_FOUND when the views response is not an array', async () => {
+      // A 2xx non-JSON body resolves to null inside vikunjaRestRequest.
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      try {
+        await resolveKanbanViewId(authManager, 9);
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.NOT_FOUND);
+        expect((error as MCPError).message).toBe(
+          'Project 9 has no Kanban view, so it has no buckets',
+        );
+      }
+    });
+
+    it('propagates an MCPError raised by the underlying request', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ ok: false, status: 403, statusText: 'Forbidden', text: 'nope' }),
+      );
+
+      await expect(resolveKanbanViewId(authManager, 4)).rejects.toThrow(MCPError);
+    });
+  });
+});


### PR DESCRIPTION
# PR: Add Kanban bucket operations + fix cross-project move data loss

## Summary

This PR adds the ability to work with Kanban buckets — placing tasks into
columns — which the Vikunja API supports but this MCP server did not expose.
It also fixes two data-loss bugs that surface when a task changes project.

## What's new

- **`vikunja_tasks set-bucket`** — moves a task into a Kanban bucket. The
  project id and Kanban view id are resolved automatically from the task
  when not supplied (`bucketId` is the only required argument besides `id`).
- **`vikunja_projects list-buckets`** — lists the buckets of a project's
  Kanban view, so a bucket can be resolved by name (e.g. "Doing") instead
  of hard-coding numeric ids.
- **`src/utils/vikunja-rest.ts`** — a small shared helper that calls the
  Vikunja REST API directly, because `node-vikunja` does not expose the
  Kanban view endpoints (`/projects/{p}/views`, `/projects/{p}/views/{v}/buckets`,
  `/projects/{p}/views/{v}/buckets/{b}/tasks`). It reuses the active session
  credentials and tolerates an `apiUrl` configured with or without the
  `/api/v1` suffix.

## Bug fixes

- **`vikunja_tasks update` ignored `projectId`.** The tool schema accepted
  `projectId`, but `UpdateTaskArgs` omitted it, so `analyzeUpdateState` and
  `buildUpdateData` never applied it — moving a task to another project via
  `update` silently did nothing.

- **`vikunja_tasks bulk-update` with `field=project_id` truncated data.**
  That path used the native Vikunja bulk endpoint, whose response returns
  tasks with `description` and `priority` blanked; the wrapper accepted the
  response as-is, corrupting those fields on every moved task. `project_id`
  bulk updates now route through the existing field-preserving per-task
  fallback (`getTask` + merge + `updateTask`).

## Tests

- 48 new tests across 3 suites: `tests/utils/vikunja-rest.test.ts`,
  `tests/tools/tasks/buckets.test.ts`, `tests/tools/projects/buckets.test.ts`.
- 100% branch / line / function coverage on the three new source files.
- Covers URL normalization, HTTP error handling, network failures,
  empty/non-JSON bodies, missing Kanban views, id validation, and the
  project/view id auto-resolution paths.

## Test plan

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] Manual: `set-bucket` moves a card in the Vikunja UI Kanban board
- [ ] Manual: `list-buckets` returns the project's columns
- [ ] Manual: `update` with `projectId` moves a task and keeps description/priority
- [ ] Manual: `bulk-update` with `field=project_id` keeps description/priority
