### PR TITLE
fix: aggregate per-project tasks when /tasks/all is unavailable

### DIFF
--- a/src/utils/filtering/ClientSideFilteringStrategy.ts
+++ b/src/utils/filtering/ClientSideFilteringStrategy.ts
@@ -8,10 +8,49 @@
 
 import type { TaskFilteringStrategy } from './TaskFilteringStrategy';
 import type { FilteringParams, FilteringResult } from './types';
+import type { VikunjaClient, Task, GetTasksParams } from 'node-vikunja';
 import { getClientFromContext } from '../../client';
 import { validateId } from '../../tools/tasks/validation';
 import { applyFilter } from '../../tools/tasks/filtering';
 import { logger } from '../logger';
+
+/**
+ * Loads tasks from every project the user can access.
+ *
+ * Vikunja's dedicated "all tasks" endpoint (client.tasks.getAllTasks ->
+ * GET /tasks/all) returns HTTP 400 "Invalid model provided" on some servers
+ * (reproduced on v2.3.0), so it cannot be relied on for cross-project listing.
+ * This aggregates GET /projects/{id}/tasks across every project instead, which
+ * is consistently available. A project that fails individually is skipped
+ * rather than failing the whole listing.
+ */
+async function loadTasksAcrossProjects(
+  client: VikunjaClient,
+  params: GetTasksParams,
+): Promise<Task[]> {
+  const projects = await client.projects.getProjects({ per_page: 1000 });
+
+  const perProject = await Promise.all(
+    projects.map(async (project): Promise<Task[]> => {
+      const projectId = project.id;
+      // Skip pseudo-projects (e.g. Favorites uses a negative id) to avoid duplicate tasks.
+      if (typeof projectId !== 'number' || projectId <= 0) {
+        return [];
+      }
+      try {
+        return await client.tasks.getProjectTasks(projectId, params);
+      } catch (error) {
+        logger.warn('Skipping a project that failed during all-projects task aggregation', {
+          projectId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return [];
+      }
+    }),
+  );
+
+  return perProject.flat();
+}
 
 export class ClientSideFilteringStrategy implements TaskFilteringStrategy {
   async execute(params: FilteringParams): Promise<FilteringResult> {
@@ -21,9 +60,11 @@ export class ClientSideFilteringStrategy implements TaskFilteringStrategy {
     
     logger.info('Using client-side filtering', {
       filter: filterString,
-      endpoint: args.projectId && !args.allProjects ? 'getProjectTasks' : 'getAllTasks'
+      endpoint: args.projectId && !args.allProjects
+        ? 'getProjectTasks'
+        : 'getProjectTasks (aggregated across all projects)'
     });
-    
+
     // Load tasks without server-side filtering
     let tasks;
     if (args.projectId !== undefined && !args.allProjects) {
@@ -32,8 +73,8 @@ export class ClientSideFilteringStrategy implements TaskFilteringStrategy {
       // Get tasks for specific project without filter
       tasks = await client.tasks.getProjectTasks(args.projectId, apiParams);
     } else {
-      // Get all tasks across all projects without filter  
-      tasks = await client.tasks.getAllTasks(apiParams);
+      // Aggregate tasks across all projects (GET /tasks/all is unreliable).
+      tasks = await loadTasksAcrossProjects(client, apiParams);
     }
     
     logger.info('Tasks loaded for client-side filtering', {


### PR DESCRIPTION
## Problem

`vikunja_tasks` / `vikunja_task_crud` `list` operations that span all projects (`allProjects: true`, or simply omitting `projectId`) route through `client.tasks.getAllTasks()` → `GET /tasks/all`.

On some Vikunja servers that endpoint is unusable. On Vikunja **v2.3.0** it returns `HTTP 400` for *every* request, regardless of query parameters:

```
GET /api/v1/tasks/all  →  400 {"code":2004,"message":"Invalid model provided"}
```

(Verified with direct `curl`, with and without `s` / `sort_by` / pagination.) Every cross-project task listing then fails with `Failed to list tasks: Invalid model provided`, while per-project listing (`GET /projects/{id}/tasks`) works normally.

## Fix

`ClientSideFilteringStrategy` no longer calls `getAllTasks()`. When no single project is targeted it aggregates `GET /projects/{id}/tasks` across every project the user can access (`projects.getProjects()` + `Promise.all`). A project that fails individually is logged and skipped rather than failing the whole listing. Pseudo-projects (negative ids, e.g. Favorites) are skipped to avoid duplicate tasks.

## Notes

- Single-project listings (`projectId` set, `allProjects` not set) are unchanged.
- Verified end-to-end against a live Vikunja v2.3.0 instance: cross-project listings that previously errored now return aggregated results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)