### PR TITLE
fix: persist task labels across create, update, apply-label and bulk

### DIFF
--- a/src/services/TaskCreationService.ts
+++ b/src/services/TaskCreationService.ts
@@ -2,6 +2,7 @@ import { logger } from '../utils/logger';
 import type { TaskCreationData } from '../types';
 import { MCPError, ErrorCode } from '../types';
 import { isAuthenticationError } from '../utils/auth-error-handler';
+import { setTaskLabels } from '../utils/label-bulk';
 import type { Task, Label, User } from 'node-vikunja';
 import type { TypedVikunjaClient } from '../types/node-vikunja-extended';
 import type { ImportedTask } from '../parsers/InputParserFactory';
@@ -267,9 +268,7 @@ export class TaskCreationService {
     if (labelIds.length > 0 && createdTask.id) {
       try {
         // Try to update labels
-        const updateResult = await client.tasks.updateTaskLabels(createdTask.id, {
-          label_ids: labelIds,
-        });
+        await setTaskLabels(client, createdTask.id, labelIds);
 
         // Verify the labels were actually assigned (API tokens may silently fail)
         const labelsActuallyAssigned = await this.verifyLabelAssignment(client, createdTask.id, labelIds);
@@ -280,7 +279,6 @@ export class TaskCreationService {
             taskId: createdTask.id,
             labelIds,
             labelNames: task.labels,
-            updateResult,
           });
           warnings.push(`Labels specified but not assigned (API token limitation). Consider using JWT authentication for label support.`);
         } else {

--- a/src/tools/projects/buckets.ts
+++ b/src/tools/projects/buckets.ts
@@ -1,0 +1,95 @@
+/**
+ * Project Kanban bucket operations
+ *
+ * Implements `list-buckets`, which returns the buckets (columns) of a
+ * project's Kanban view. This lets callers resolve a bucket by name (e.g.
+ * "Doing") instead of hard-coding numeric bucket ids.
+ *
+ * node-vikunja does not expose the Kanban view endpoints, so this calls the
+ * Vikunja REST API directly via the shared `vikunja-rest` helper.
+ */
+
+import type { AuthManager } from '../../auth/AuthManager';
+import { MCPError, ErrorCode } from '../../types';
+import { validateId } from '../../utils/validation';
+import { createStandardResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../utils/vikunja-rest';
+
+export interface ListBucketsArgs {
+  /** Project whose Kanban buckets should be listed. */
+  id?: number;
+  /** Optional Kanban view id. Auto-resolved from the project when omitted. */
+  viewId?: number;
+  /** Session id for response tracking. */
+  sessionId?: string;
+}
+
+interface VikunjaBucket {
+  id: number;
+  title: string;
+  project_view_id?: number;
+  position?: number;
+  limit?: number;
+  is_done_bucket?: boolean;
+}
+
+/**
+ * Lists the Kanban buckets of a project.
+ *
+ * @param args - Project id and optional view id
+ * @param authManager - Active auth manager holding session credentials
+ * @returns MCP response containing the project's Kanban buckets
+ */
+export async function listBuckets(
+  args: ListBucketsArgs,
+  authManager: AuthManager,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  if (!args.id) {
+    throw new MCPError(
+      ErrorCode.VALIDATION_ERROR,
+      'Project id is required for list-buckets operation',
+    );
+  }
+  validateId(args.id, 'id');
+  if (args.viewId !== undefined) validateId(args.viewId, 'viewId');
+
+  const viewId =
+    args.viewId !== undefined ? args.viewId : await resolveKanbanViewId(authManager, args.id);
+
+  const buckets = await vikunjaRestRequest<VikunjaBucket[]>(
+    authManager,
+    'GET',
+    `/projects/${args.id}/views/${viewId}/buckets`,
+  );
+  const bucketList = Array.isArray(buckets) ? buckets : [];
+
+  const response = createStandardResponse(
+    'list-buckets',
+    `Found ${bucketList.length} buckets in the Kanban view of project ${args.id}`,
+    {
+      projectId: args.id,
+      viewId,
+      buckets: bucketList.map((bucket) => ({
+        id: bucket.id,
+        title: bucket.title,
+        position: bucket.position,
+        limit: bucket.limit,
+        isDoneBucket: bucket.is_done_bucket ?? false,
+      })),
+    },
+    {
+      timestamp: new Date().toISOString(),
+      count: bucketList.length,
+    },
+    args.sessionId,
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: formatAorpAsMarkdown(response),
+      },
+    ],
+  };
+}

--- a/src/tools/projects/index.ts
+++ b/src/tools/projects/index.ts
@@ -53,6 +53,8 @@ import {
   type AuthShareArgs
 } from './sharing';
 
+import { listBuckets, type ListBucketsArgs } from './buckets';
+
 /**
  * Legacy single-tool interface for backward compatibility
  * Registers a single tool with all subcommands like the original implementation
@@ -64,11 +66,12 @@ export function registerProjectsTool(
 ): void {
   server.tool(
     'vikunja_projects',
-    'Manage projects with full CRUD operations, hierarchy management, and sharing capabilities',
+    'Manage projects with full CRUD operations, hierarchy management, sharing capabilities, and Kanban bucket listing',
     {
       subcommand: z.enum(['list', 'get', 'create', 'update', 'delete', 'archive', 'unarchive',
         'get-children', 'get-tree', 'get-breadcrumb', 'move',
-        'create-share', 'list-shares', 'get-share', 'delete-share', 'auth-share'
+        'create-share', 'list-shares', 'get-share', 'delete-share', 'auth-share',
+        'list-buckets'
       ]),
       // CRUD arguments
       id: z.number().positive().optional(),
@@ -83,6 +86,8 @@ export function registerProjectsTool(
       // Hierarchy arguments
       maxDepth: z.number().min(1).max(20).optional(),
       includeArchived: z.boolean().optional(),
+      // Kanban bucket arguments (list-buckets subcommand)
+      viewId: z.number().positive().optional(),
       // Sharing arguments
       projectId: z.number().positive().optional(),
       shareId: z.string().optional(),
@@ -218,6 +223,14 @@ export function registerProjectsTool(
             if (args.password !== undefined) authShareArgs.password = args.password;
             return await authProjectShare(authShareArgs);
           }
+
+          // Kanban bucket operations
+          case 'list-buckets':
+            if (!args.id) {
+              throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Project ID is required for list-buckets operation');
+            }
+            validateId(args.id, 'id');
+            return await listBuckets(args as ListBucketsArgs, authManager);
 
           default:
             throw new MCPError(ErrorCode.VALIDATION_ERROR, `Unknown subcommand: ${String(args.subcommand)}`);

--- a/src/tools/projects/index.ts
+++ b/src/tools/projects/index.ts
@@ -86,8 +86,10 @@ export function registerProjectsTool(
       // Hierarchy arguments
       maxDepth: z.number().min(1).max(20).optional(),
       includeArchived: z.boolean().optional(),
-      // Kanban bucket arguments (list-buckets subcommand)
-      viewId: z.number().positive().optional(),
+      // Kanban bucket arguments (list-buckets subcommand).
+      // z.coerce tolerates MCP clients whose cached tool schema predates
+      // this param and therefore send it as a string over JSON-RPC.
+      viewId: z.coerce.number().positive().optional(),
       // Sharing arguments
       projectId: z.number().positive().optional(),
       shareId: z.string().optional(),

--- a/src/tools/tasks/buckets.ts
+++ b/src/tools/tasks/buckets.ts
@@ -1,0 +1,121 @@
+/**
+ * Task Kanban bucket operations
+ *
+ * Implements `set-bucket`, which moves a task into a Kanban bucket (column)
+ * of its project's Kanban view. This is the operation behind a "move card to
+ * the Doing column" workflow.
+ *
+ * node-vikunja does not expose the Kanban view endpoints, so this calls the
+ * Vikunja REST API directly via the shared `vikunja-rest` helper.
+ */
+
+import type { AuthManager } from '../../auth/AuthManager';
+import { MCPError, ErrorCode } from '../../types';
+import { validateId } from '../../utils/validation';
+import { createStandardResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../utils/vikunja-rest';
+
+export interface SetTaskBucketArgs {
+  /** Id of the task to move. */
+  id?: number;
+  /** Id of the destination Kanban bucket. */
+  bucketId?: number;
+  /** Optional Kanban view id. Auto-resolved from the project when omitted. */
+  viewId?: number;
+  /** Optional project id. Auto-resolved from the task when omitted. */
+  projectId?: number;
+  /** Session id for response tracking. */
+  sessionId?: string;
+}
+
+interface VikunjaTaskSummary {
+  id: number;
+  project_id: number;
+  title?: string;
+}
+
+/**
+ * Moves a task into a Kanban bucket.
+ *
+ * Resolution order when optional ids are omitted:
+ *  - projectId: fetched from the task itself
+ *  - viewId: resolved to the project's Kanban view
+ *
+ * @param args - Task id, destination bucket id, and optional view/project ids
+ * @param authManager - Active auth manager holding session credentials
+ * @returns MCP response describing the move
+ */
+export async function setTaskBucket(
+  args: SetTaskBucketArgs,
+  authManager: AuthManager,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  if (!args.id) {
+    throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Task id is required for set-bucket operation');
+  }
+  if (args.bucketId === undefined || args.bucketId === null) {
+    throw new MCPError(
+      ErrorCode.VALIDATION_ERROR,
+      'bucketId is required for set-bucket operation',
+    );
+  }
+  validateId(args.id, 'id');
+  validateId(args.bucketId, 'bucketId');
+  if (args.viewId !== undefined) validateId(args.viewId, 'viewId');
+  if (args.projectId !== undefined) validateId(args.projectId, 'projectId');
+
+  // Resolve the project id from the task when the caller did not supply it.
+  let projectId = args.projectId;
+  if (projectId === undefined) {
+    const task = await vikunjaRestRequest<VikunjaTaskSummary>(
+      authManager,
+      'GET',
+      `/tasks/${args.id}`,
+    );
+    if (!task || typeof task.project_id !== 'number') {
+      throw new MCPError(
+        ErrorCode.NOT_FOUND,
+        `Could not resolve the project of task ${args.id}`,
+      );
+    }
+    projectId = task.project_id;
+  }
+
+  // Resolve the Kanban view id when the caller did not supply it.
+  const viewId =
+    args.viewId !== undefined ? args.viewId : await resolveKanbanViewId(authManager, projectId);
+
+  // Place the task into the bucket. Vikunja's bucket-task endpoint expects the
+  // TaskBucket payload; bucket_id is also part of the URL but is sent in the
+  // body as the API model requires it.
+  await vikunjaRestRequest(
+    authManager,
+    'POST',
+    `/projects/${projectId}/views/${viewId}/buckets/${args.bucketId}/tasks`,
+    { task_id: args.id, bucket_id: args.bucketId },
+  );
+
+  const response = createStandardResponse(
+    'set-task-bucket',
+    `Task ${args.id} moved to bucket ${args.bucketId}`,
+    {
+      taskId: args.id,
+      bucketId: args.bucketId,
+      viewId,
+      projectId,
+    },
+    {
+      timestamp: new Date().toISOString(),
+      affectedFields: ['bucket_id'],
+    },
+    args.sessionId,
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: formatAorpAsMarkdown(response),
+      },
+    ],
+  };
+}

--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -100,6 +100,15 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
 
     try {
       if (!args.field) throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Field required');
+
+      // The native Vikunja bulk endpoint truncates fields it does not receive
+      // (description, priority, ...) when moving tasks across projects, which
+      // silently corrupts task data. Route project_id moves through the
+      // field-preserving per-task path (getTask + merge + updateTask) instead.
+      if (args.field === 'project_id') {
+        return await updateWithFallback();
+      }
+
       const bulkOp = { task_ids: taskIds, field: args.field, value: args.value };
       if (args.field === 'repeat_mode' && typeof args.value === 'string') {
         bulkOp.value = REPEAT_MODE_MAP[args.value] ?? args.value;

--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -6,6 +6,7 @@
 import { MCPError, ErrorCode, createStandardResponse, getClientFromContext, logger, isAuthenticationError, RETRY_CONFIG, transformApiError, handleFetchError } from '../../index';
 import type { Assignee } from '../../types';
 import { withRetry } from '../../utils/retry';
+import { setTaskLabels } from '../../utils/label-bulk';
 import { BatchProcessor } from '../../utils/performance/batch-processor';
 import type { Task } from 'node-vikunja';
 import { convertRepeatConfiguration, applyFieldUpdate } from './validation';
@@ -79,7 +80,7 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
           }
         }
         if (args.field === 'labels' && Array.isArray(args.value)) {
-          await withRetry(() => client.tasks.updateTaskLabels(taskId, { label_ids: args.value as number[] }), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
+          await withRetry(() => setTaskLabels(client, taskId, args.value as number[]), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
         }
         return updated;
       });
@@ -101,11 +102,12 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
     try {
       if (!args.field) throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Field required');
 
-      // The native Vikunja bulk endpoint truncates fields it does not receive
-      // (description, priority, ...) when moving tasks across projects, which
-      // silently corrupts task data. Route project_id moves through the
-      // field-preserving per-task path (getTask + merge + updateTask) instead.
-      if (args.field === 'project_id') {
+      // The native Vikunja bulk endpoint does not apply label relations and,
+      // for project_id moves, truncates fields it does not receive
+      // (description, priority, ...), silently corrupting task data. Route
+      // both through the field-preserving per-task path (getTask + merge +
+      // updateTask, plus a dedicated /labels/bulk call for labels) instead.
+      if (args.field === 'project_id' || args.field === 'labels') {
         return await updateWithFallback();
       }
 
@@ -228,7 +230,7 @@ export async function bulkCreateTasks(args: BulkCreateArgs): Promise<{ content: 
 
         try {
           const labels = t.labels;
-          if (labels && labels.length > 0) await withRetry(() => client.tasks.updateTaskLabels(createdId, { label_ids: labels }), { maxRetries: RETRY_CONFIG.AUTH_ERRORS.maxRetries ?? 3, timeout: (RETRY_CONFIG.AUTH_ERRORS.initialDelay ?? 1000) + (RETRY_CONFIG.AUTH_ERRORS.maxDelay ?? 10000), shouldRetry: isAuthenticationError });
+          if (labels && labels.length > 0) await withRetry(() => setTaskLabels(client, createdId, labels), { maxRetries: RETRY_CONFIG.AUTH_ERRORS.maxRetries ?? 3, timeout: (RETRY_CONFIG.AUTH_ERRORS.initialDelay ?? 1000) + (RETRY_CONFIG.AUTH_ERRORS.maxDelay ?? 10000), shouldRetry: isAuthenticationError });
           const assignees = t.assignees;
           if (assignees && assignees.length > 0) {
             try {

--- a/src/tools/tasks/bulk/BulkOperationValidator.ts
+++ b/src/tools/tasks/bulk/BulkOperationValidator.ts
@@ -33,6 +33,54 @@ export interface BulkCreateArgs {
 }
 
 /**
+ * Coerce a labels/assignees value into a number array.
+ *
+ * The bulk-update `value` field is loosely typed (z.unknown), and an MCP
+ * client with a stale cached schema may send the array as a JSON string
+ * ("[3,8]") or a comma-separated string ("3,8") instead of a real array.
+ * Returns the value unchanged when it cannot be coerced, so that
+ * validateFieldConstraints still reports a clear error.
+ */
+function coerceToNumberArray(value: unknown): unknown {
+  const toNumbers = (arr: unknown[]): unknown[] =>
+    arr.map((item) =>
+      typeof item === 'string' && item.trim() !== '' && !Number.isNaN(Number(item))
+        ? Number(item)
+        : item,
+    );
+
+  if (Array.isArray(value)) {
+    return toNumbers(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return value;
+    }
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return toNumbers(parsed);
+        }
+      } catch {
+        // Not valid JSON; fall through to comma-separated handling.
+      }
+    }
+    const parts = trimmed
+      .split(',')
+      .map((part) => part.trim())
+      .filter((part) => part !== '');
+    if (parts.length > 0 && parts.every((part) => !Number.isNaN(Number(part)))) {
+      return parts.map((part) => Number(part));
+    }
+  }
+
+  return value;
+}
+
+/**
  * Validator for bulk update operations
  */
 export const bulkOperationValidator = {
@@ -84,6 +132,13 @@ export const bulkOperationValidator = {
       if (!isNaN(numValue)) {
         args.value = numValue;
       }
+    }
+
+    // labels and assignees expect a number[]; coerce a stringified array
+    // ("[3,8]" or "3,8") that a stale client schema may send so a valid
+    // value is not rejected as "must be an array of numbers".
+    if (args.field && ['labels', 'assignees'].includes(args.field)) {
+      args.value = coerceToNumberArray(args.value);
     }
   },
 

--- a/src/tools/tasks/crud/TaskCreationService.ts
+++ b/src/tools/tasks/crud/TaskCreationService.ts
@@ -9,6 +9,7 @@ import type { Task, VikunjaClient } from 'node-vikunja';
 import { logger } from '../../../utils/logger';
 import { isAuthenticationError } from '../../../utils/auth-error-handler';
 import { withRetry, RETRY_CONFIG } from '../../../utils/retry';
+import { setTaskLabels } from '../../../utils/label-bulk';
 import { transformApiError, handleFetchError } from '../../../utils/error-handler';
 import { sanitizeString } from '../../../utils/validation';
 import { AUTH_ERROR_MESSAGES } from '../constants';
@@ -131,8 +132,12 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
       {
         timestamp: new Date().toISOString(),
         projectId: args.projectId,
-        labelsAdded: args.labels ? args.labels.length > 0 : false,
-        assigneesAdded: args.assignees ? args.assignees.length > 0 : false,
+        // Reflect what was actually persisted, not merely what was requested:
+        // if label/assignee attachment fails the task creation is rolled back
+        // and this response is never reached, so these flags are only true
+        // once the corresponding step has genuinely succeeded.
+        labelsAdded: creationState.labelsAdded,
+        assigneesAdded: creationState.assigneesAdded,
       },
       undefined, // verbosity (ignored - using standard AORP)
       undefined, // useOptimizedFormat (ignored - using standard AORP)
@@ -180,9 +185,7 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
 async function addLabelsToTask(client: VikunjaClient, taskId: number, labelIds: number[]): Promise<void> {
   try {
     await withRetry(
-      () => client.tasks.updateTaskLabels(taskId, {
-        label_ids: labelIds,
-      }),
+      () => setTaskLabels(client, taskId, labelIds),
       {
         ...RETRY_CONFIG.AUTH_ERRORS,
         shouldRetry: (error) => isAuthenticationError(error)

--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -18,6 +18,7 @@ export interface UpdateTaskArgs {
   id?: number;
   title?: string;
   description?: string;
+  projectId?: number;
   dueDate?: string;
   priority?: number;
   done?: boolean;
@@ -132,6 +133,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   const previousState: Record<string, unknown> = {};
   if (currentTask.title !== undefined) previousState.title = currentTask.title;
   if (currentTask.description !== undefined) previousState.description = currentTask.description;
+  if (currentTask.project_id !== undefined) previousState.project_id = currentTask.project_id;
   if (currentTask.due_date !== undefined) previousState.due_date = currentTask.due_date;
   if (currentTask.priority !== undefined) previousState.priority = currentTask.priority;
   if (currentTask.done !== undefined) previousState.done = currentTask.done;
@@ -143,6 +145,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
 
   if (args.title !== undefined && args.title !== currentTask.title) affectedFields.push('title');
   if (args.description !== undefined && args.description !== currentTask.description) affectedFields.push('description');
+  if (args.projectId !== undefined && args.projectId !== currentTask.project_id) affectedFields.push('projectId');
   if (args.dueDate !== undefined && args.dueDate !== currentTask.due_date) affectedFields.push('dueDate');
   if (args.priority !== undefined && args.priority !== currentTask.priority) affectedFields.push('priority');
   if (args.done !== undefined && args.done !== currentTask.done) affectedFields.push('done');
@@ -168,6 +171,7 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
     // Override with any provided updates
     ...(args.title !== undefined && { title: args.title }),
     ...(args.description !== undefined && { description: args.description }),
+    ...(args.projectId !== undefined && { project_id: args.projectId }),
     ...(args.dueDate !== undefined && { due_date: args.dueDate }),
     ...(args.priority !== undefined && { priority: args.priority }),
     ...(args.done !== undefined && { done: args.done }),

--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -9,6 +9,7 @@ import type { Task, VikunjaClient } from 'node-vikunja';
 import { validateDateString, validateId, convertRepeatConfiguration } from '../validation';
 import { isAuthenticationError } from '../../../utils/auth-error-handler';
 import { RETRY_CONFIG } from '../../../utils/retry';
+import { setTaskLabels } from '../../../utils/label-bulk';
 import { transformApiError, handleFetchError, handleStatusCodeError } from '../../../utils/error-handler';
 import { AUTH_ERROR_MESSAGES } from '../constants';
 import { createTaskResponse } from './TaskResponseFormatter';
@@ -199,9 +200,7 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
  */
 async function updateTaskLabels(client: VikunjaClient, taskId: number, labelIds: number[]): Promise<void> {
   try {
-    await client.tasks.updateTaskLabels(taskId, {
-      label_ids: labelIds,
-    });
+    await setTaskLabels(client, taskId, labelIds);
   } catch (labelError) {
     // Check if it's an auth error
     if (isAuthenticationError(labelError)) {

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -157,9 +157,11 @@ export function registerTasksTool(
       priority: z.number().min(0).max(5).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
-      // Kanban bucket fields (set-bucket subcommand)
-      bucketId: z.number().optional(),
-      viewId: z.number().optional(),
+      // Kanban bucket fields (set-bucket subcommand).
+      // z.coerce tolerates MCP clients whose cached tool schema predates
+      // these params and therefore send them as strings over JSON-RPC.
+      bucketId: z.coerce.number().optional(),
+      viewId: z.coerce.number().optional(),
       // Recurring task fields
       repeatAfter: z.number().min(0).optional(),
       repeatMode: z.enum(['day', 'week', 'month', 'year']).optional(),

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -25,6 +25,7 @@ import { assignUsers, unassignUsers, listAssignees } from './assignees';
 import { handleComment } from './comments';
 import { addReminder, removeReminder, listReminders } from './reminders';
 import { applyLabels, removeLabels, listTaskLabels } from './labels';
+import { setTaskBucket } from './buckets';
 
 
 /**
@@ -121,7 +122,7 @@ export function registerTasksTool(
 ): void {
   server.tool(
     'vikunja_tasks',
-    'Manage tasks with comprehensive operations (create, update, delete, list, assign, attach files, comment, bulk operations)',
+    'Manage tasks with comprehensive operations (create, update, delete, list, assign, attach files, comment, bulk operations, set Kanban bucket)',
     {
       subcommand: z.enum([
         'create',
@@ -146,6 +147,7 @@ export function registerTasksTool(
         'apply-label',
         'remove-label',
         'list-labels',
+        'set-bucket',
       ]),
       // Task creation/update fields
       title: z.string().optional(),
@@ -155,6 +157,9 @@ export function registerTasksTool(
       priority: z.number().min(0).max(5).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
+      // Kanban bucket fields (set-bucket subcommand)
+      bucketId: z.number().optional(),
+      viewId: z.number().optional(),
       // Recurring task fields
       repeatAfter: z.number().min(0).optional(),
       repeatMode: z.enum(['day', 'week', 'month', 'year']).optional(),
@@ -286,6 +291,9 @@ export function registerTasksTool(
 
           case 'list-labels':
             return listTaskLabels(args as Parameters<typeof listTaskLabels>[0]);
+
+          case 'set-bucket':
+            return setTaskBucket(args as Parameters<typeof setTaskBucket>[0], authManager);
 
           default:
             throw new MCPError(

--- a/src/tools/tasks/labels.ts
+++ b/src/tools/tasks/labels.ts
@@ -11,7 +11,23 @@ import { validateId } from './validation';
 import { createSimpleResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
 
 /**
+ * Detects Vikunja's "label already exists on the task" response so that a
+ * duplicate label can be treated as a no-op rather than a fatal error.
+ */
+function isLabelAlreadyOnTaskError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.message.toLowerCase().includes('already exists');
+}
+
+/**
  * Add labels to a task
+ *
+ * Idempotent: labels already on the task are skipped instead of aborting the
+ * whole operation. Vikunja rejects a duplicate label with "label already
+ * exists on the task"; treating that as fatal previously stopped the loop and
+ * left the remaining requested labels unapplied.
  */
 export async function applyLabels(args: {
   id?: number;
@@ -35,10 +51,35 @@ export async function applyLabels(args: {
 
     const client = await getClientFromContext();
     const taskId = args.id;
-    const labelIds = args.labels;
+    // Deduplicate so a repeated id is not applied or counted twice
+    const requestedLabelIds = [...new Set(args.labels)];
 
-    // Add labels to the task with retry logic
-    for (const labelId of labelIds) {
+    // Skip labels already on the task: applying a duplicate makes Vikunja
+    // reject the request, so pre-filtering keeps the operation idempotent.
+    const alreadyPresent: number[] = [];
+    let toApply = requestedLabelIds;
+    try {
+      const currentLabels = await client.tasks.getTaskLabels(taskId);
+      const existingIds = new Set(
+        (Array.isArray(currentLabels) ? currentLabels : [])
+          .map((label) => label.id)
+          .filter((id): id is number => typeof id === 'number'),
+      );
+      toApply = requestedLabelIds.filter((id) => {
+        if (existingIds.has(id)) {
+          alreadyPresent.push(id);
+          return false;
+        }
+        return true;
+      });
+    } catch {
+      // Current labels could not be read; attempt every requested label.
+      // A duplicate is still tolerated per-label below.
+    }
+
+    // Add the remaining labels to the task with retry logic
+    const newlyApplied: number[] = [];
+    for (const labelId of toApply) {
       try {
         await withRetry(
           () =>
@@ -51,6 +92,7 @@ export async function applyLabels(args: {
             shouldRetry: (error: unknown) => isAuthenticationError(error),
           },
         );
+        newlyApplied.push(labelId);
       } catch (labelError) {
         // Check if it's an auth error after retries
         if (isAuthenticationError(labelError)) {
@@ -59,18 +101,40 @@ export async function applyLabels(args: {
             `Failed to apply label to task (Retried ${RETRY_CONFIG.AUTH_ERRORS.maxRetries} times)`,
           );
         }
+        // A label already on the task is not a failure: skip it and keep
+        // applying the rest instead of aborting the whole operation.
+        if (isLabelAlreadyOnTaskError(labelError)) {
+          alreadyPresent.push(labelId);
+          continue;
+        }
         throw labelError;
       }
     }
 
     // Fetch the updated task to show current labels
-    const task = await client.tasks.getTask(args.id);
+    const task = await client.tasks.getTask(taskId);
+
+    let message: string;
+    if (newlyApplied.length > 0) {
+      message = `Label${newlyApplied.length > 1 ? 's' : ''} applied to task successfully`;
+      if (alreadyPresent.length > 0) {
+        message += ` (${alreadyPresent.length} already present, skipped)`;
+      }
+    } else {
+      message = `No labels applied: all ${alreadyPresent.length} requested label(s) already present on the task`;
+    }
 
     const response = createSimpleResponse(
       'apply-label',
-      `Label${labelIds.length > 1 ? 's' : ''} applied to task successfully`,
+      message,
       { task },
-      { metadata: { affectedFields: ['labels'] } }
+      {
+        metadata: {
+          affectedFields: ['labels'],
+          labelsApplied: newlyApplied,
+          labelsAlreadyPresent: alreadyPresent,
+        },
+      }
     );
 
     return {
@@ -82,6 +146,9 @@ export async function applyLabels(args: {
       ],
     };
   } catch (error) {
+    if (error instanceof MCPError) {
+      throw error;
+    }
     throw new MCPError(
       ErrorCode.API_ERROR,
       `Failed to apply labels to task: ${error instanceof Error ? error.message : String(error)}`,
@@ -163,6 +230,10 @@ export async function removeLabels(args: {
 
 /**
  * List labels of a task
+ *
+ * Reads the labels from the dedicated GET /tasks/{id}/labels endpoint. The
+ * labels array embedded in a getTask response is not reliably populated, so
+ * relying on it reported zero labels on tasks that actually had some.
  */
 export async function listTaskLabels(args: {
   id?: number;
@@ -178,10 +249,12 @@ export async function listTaskLabels(args: {
 
     const client = await getClientFromContext();
 
-    // Fetch the task to get current labels
-    const task = await client.tasks.getTask(args.id);
+    // Authoritative source for a task's labels
+    const taskLabels = await client.tasks.getTaskLabels(args.id);
+    const labels = Array.isArray(taskLabels) ? taskLabels : [];
 
-    const labels = task.labels || [];
+    // Fetch the task itself only for its identifying fields
+    const task = await client.tasks.getTask(args.id);
 
     const minimalTask: MinimalTask = {
       ...(task.id !== undefined && { id: task.id }),

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -12,6 +12,7 @@ import { getClientFromContext } from '../client';
 import type { Project, Task } from 'node-vikunja';
 import { storageManager } from '../storage';
 import { logger } from '../utils/logger';
+import { setTaskLabels } from '../utils/label-bulk';
 import { formatAorpAsMarkdown } from '../utils/response-factory';
 
 /**
@@ -381,9 +382,7 @@ export function registerTemplatesTool(server: McpServer, authManager: AuthManage
                   // Add labels if any
                   if (taskTemplate.labels && taskTemplate.labels.length > 0) {
                     try {
-                      await client.tasks.updateTaskLabels(createdTask.id ?? 0, {
-                        label_ids: taskTemplate.labels,
-                      });
+                      await setTaskLabels(client, createdTask.id ?? 0, taskTemplate.labels);
                     } catch (labelError) {
                       logger.warn('Failed to add labels to task', {
                         taskId: createdTask.id,

--- a/src/utils/label-bulk.ts
+++ b/src/utils/label-bulk.ts
@@ -1,0 +1,29 @@
+/**
+ * Helper for replacing the full label set of a task.
+ */
+
+import type { VikunjaClient } from 'node-vikunja';
+
+/**
+ * Replace all labels on a task via `POST /tasks/{id}/labels/bulk`.
+ *
+ * node-vikunja types this endpoint's body as `{ label_ids: number[] }`, but
+ * current Vikunja silently ignores that field: it responds `201` and persists
+ * nothing. Vikunja actually requires `{ labels: [{ id }, ...] }`. We send the
+ * shape Vikunja accepts; the cast is required because node-vikunja's
+ * `LabelTaskBulk` type does not describe it.
+ *
+ * The endpoint has replace semantics — the task's labels become exactly
+ * `labelIds` (passing `[]` clears every label).
+ */
+export async function setTaskLabels(
+  client: VikunjaClient,
+  taskId: number,
+  labelIds: number[],
+): Promise<void> {
+  const body = { labels: labelIds.map((id) => ({ id })) };
+  await client.tasks.updateTaskLabels(
+    taskId,
+    body as unknown as Parameters<VikunjaClient['tasks']['updateTaskLabels']>[1],
+  );
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -124,14 +124,18 @@ export async function withRetry<T>(
   options: RetryOptions = {}
 ): Promise<T> {
   const opts = { ...DEFAULT_OPTIONS, ...options };
+  const maxRetries = opts.maxRetries ?? 3;
   let lastError: unknown;
-  let delay = opts.initialDelay || 1000;
+  let delay = opts.initialDelay ?? 1000;
 
-  for (let attempt = 0; attempt <= (opts.maxRetries || 3); attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      // Use circuit breaker for the operation
-      const breaker = createCircuitBreaker(operation, 'anonymous', opts);
-      return await breaker.fire() as Promise<T>;
+      // Execute the operation directly. It must NOT be wrapped in a
+      // name-cached circuit breaker here: opossum binds the action at
+      // construction time, so a breaker reused under a fixed name re-runs
+      // whichever closure reached it first instead of this call's
+      // operation -- silently acting on the wrong task/label/assignee.
+      return await operation();
     } catch (error) {
       lastError = error;
 
@@ -141,16 +145,14 @@ export async function withRetry<T>(
         : isRetryableError(error as Error);
 
       // If this is the last attempt or error is not retryable, throw
-      if (attempt === (opts.maxRetries || 3) || !shouldRetry) {
+      if (attempt === maxRetries || !shouldRetry) {
         throw error;
       }
 
-      // Log retry attempt
-      logger.debug(`Retry attempt ${attempt + 1}/${opts.maxRetries || 3} after ${delay}ms`);
-
-      // Wait before retrying with exponential backoff
+      // Log and wait before retrying with exponential backoff
+      logger.debug(`Retrying operation after ${delay}ms`);
       await new Promise(resolve => setTimeout(resolve, delay));
-      delay = Math.min(delay * (opts.backoffFactor || 2), opts.maxDelay || 30000);
+      delay = Math.min(delay * (opts.backoffFactor ?? 2), opts.maxDelay ?? 30000);
     }
   }
 

--- a/src/utils/vikunja-rest.ts
+++ b/src/utils/vikunja-rest.ts
@@ -1,0 +1,125 @@
+/**
+ * Direct REST helper for Vikunja API endpoints not covered by node-vikunja.
+ *
+ * node-vikunja (the typed client this MCP server wraps) does not expose the
+ * Kanban view endpoints — listing the buckets of a view, or placing a task
+ * into a bucket. Those operations therefore call the Vikunja REST API
+ * directly, reusing the credentials of the active authenticated session.
+ */
+
+import type { AuthManager } from '../auth/AuthManager';
+import { MCPError, ErrorCode } from '../types';
+
+/**
+ * Performs an authenticated request against the Vikunja REST API.
+ *
+ * @param authManager - Active auth manager holding the session credentials
+ * @param method - HTTP method
+ * @param path - API path relative to the configured apiUrl, must start with '/'
+ *               (e.g. '/projects/4/views')
+ * @param body - Optional value serialized as a JSON request body
+ * @returns The parsed JSON response, or null when the response has no body
+ * @throws MCPError when the network call fails or the response is not OK
+ */
+export async function vikunjaRestRequest<T = unknown>(
+  authManager: AuthManager,
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const session = authManager.getSession();
+  // session.apiUrl may or may not already include the `/api/v1` prefix
+  // depending on how VIKUNJA_URL was configured; normalize so REST paths
+  // (which are relative to the API root) always resolve correctly.
+  const trimmed = session.apiUrl.replace(/\/+$/, '');
+  const baseUrl = /\/api\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/api/v1`;
+  const url = `${baseUrl}${path}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${session.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (error) {
+    throw new MCPError(
+      ErrorCode.API_ERROR,
+      `Vikunja REST request failed (${method} ${path}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (!response.ok) {
+    let detail = '';
+    try {
+      detail = (await response.text()).slice(0, 500);
+    } catch {
+      // Body could not be read — fall back to the status line only.
+    }
+    throw new MCPError(
+      ErrorCode.API_ERROR,
+      `Vikunja REST request failed (${method} ${path}): HTTP ${response.status} ${
+        response.statusText
+      }${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return null as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    // A 2xx response with a non-JSON body (rare) is treated as an empty result.
+    return null as T;
+  }
+}
+
+/**
+ * Minimal shape of a Vikunja project view as returned by `/projects/{id}/views`.
+ */
+export interface VikunjaView {
+  id: number;
+  title: string;
+  project_id: number;
+  view_kind: string;
+}
+
+/**
+ * Resolves the Kanban view id for a project.
+ *
+ * Vikunja projects have several views (list, gantt, table, kanban). Bucket
+ * operations only make sense against the Kanban view, so callers that do not
+ * already know the view id can use this to find it.
+ *
+ * @param authManager - Active auth manager
+ * @param projectId - Project whose Kanban view should be resolved
+ * @returns The numeric id of the project's Kanban view
+ * @throws MCPError when the project has no Kanban view
+ */
+export async function resolveKanbanViewId(
+  authManager: AuthManager,
+  projectId: number,
+): Promise<number> {
+  const views = await vikunjaRestRequest<VikunjaView[]>(
+    authManager,
+    'GET',
+    `/projects/${projectId}/views`,
+  );
+  const kanban = Array.isArray(views)
+    ? views.find((view) => view.view_kind === 'kanban')
+    : undefined;
+  if (!kanban) {
+    throw new MCPError(
+      ErrorCode.NOT_FOUND,
+      `Project ${projectId} has no Kanban view, so it has no buckets`,
+    );
+  }
+  return kanban.id;
+}

--- a/tests/services/TaskCreationService.test.ts
+++ b/tests/services/TaskCreationService.test.ts
@@ -251,7 +251,7 @@ describe('TaskCreationService', () => {
       expect(result.success).toBe(true);
       expect(result.warnings).toBeUndefined();
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(123, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
       expect(mockClient.tasks.getTask).toHaveBeenCalledWith(123);
     });

--- a/tests/tools/batch-import.test.ts
+++ b/tests/tools/batch-import.test.ts
@@ -257,7 +257,7 @@ describe('Batch Import Tool', () => {
       });
 
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(103, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
       expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalledWith(103, {
         user_ids: [10, 11],
@@ -353,7 +353,7 @@ Task 2,Description 2,2,true`;
       });
 
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(203, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
     });
 
@@ -733,7 +733,7 @@ Description,1`;
 
       // Verify updateTaskLabels was called with correct label IDs
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(122, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
 
       // Verify getTask was called to check if labels were actually assigned
@@ -1116,7 +1116,7 @@ Description,1`;
 
       // Should map correctly despite case differences
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1101, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
     });
 
@@ -1368,7 +1368,7 @@ Description,1`;
 
       // Should update with only the found label
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1801, {
-        label_ids: [1],
+        labels: [{ id: 1 }],
       });
       
       // Task completed successfully, only 'bug' label was applied

--- a/tests/tools/projects/buckets.test.ts
+++ b/tests/tools/projects/buckets.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the project Kanban bucket listing operation (`list-buckets`).
+ *
+ * Covers id validation, view auto-resolution vs an explicit viewId, empty and
+ * non-array bucket responses, optional bucket fields, and error propagation.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../../src/auth/AuthManager';
+import { listBuckets } from '../../../src/tools/projects/buckets';
+import { MCPError, ErrorCode } from '../../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** Minimal Response-like object for the REST helper. */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+}): Response {
+  const { ok = true, status = 200, statusText = 'OK', text = '' } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+/** A views payload containing a Kanban view (id 11). */
+const kanbanViews = JSON.stringify([
+  { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+  { id: 11, title: 'Kanban', project_id: 5, view_kind: 'kanban' },
+]);
+
+describe('listBuckets', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('validation', () => {
+    it('throws a VALIDATION_ERROR when the project id is missing', async () => {
+      await expect(listBuckets({}, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'Project id is required for list-buckets operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when the project id is zero (falsy)', async () => {
+      await expect(listBuckets({ id: 0 }, authManager)).rejects.toThrow(
+        'Project id is required for list-buckets operation',
+      );
+    });
+
+    it('throws when the project id is not a positive integer', async () => {
+      await expect(listBuckets({ id: -3 }, authManager)).rejects.toThrow(
+        'id must be a positive integer',
+      );
+    });
+
+    it('throws when an explicit viewId is invalid', async () => {
+      await expect(listBuckets({ id: 5, viewId: 0 }, authManager)).rejects.toThrow(
+        'viewId must be a positive integer',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('view resolution', () => {
+    it('resolves the Kanban view id when viewId is omitted', async () => {
+      // 1) GET /projects/:id/views  2) GET buckets
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(
+          mockResponse({
+            text: JSON.stringify([
+              {
+                id: 100,
+                title: 'Backlog',
+                project_view_id: 11,
+                position: 0,
+                limit: 0,
+                is_done_bucket: false,
+              },
+              {
+                id: 101,
+                title: 'Done',
+                project_view_id: 11,
+                position: 1,
+                limit: 5,
+                is_done_bucket: true,
+              },
+            ]),
+          }),
+        );
+
+      const result = await listBuckets({ id: 5 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[1]).toBe('https://vikunja.test/api/v1/projects/5/views/11/buckets');
+
+      const text = result.content[0].text;
+      expect(text).toContain('Found 2 buckets in the Kanban view of project 5');
+      expect(text).toContain('Backlog');
+      expect(text).toContain('Done');
+    });
+
+    it('uses an explicit viewId without resolving the Kanban view', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([{ id: 100, title: 'Backlog' }]),
+        }),
+      );
+
+      const result = await listBuckets({ id: 5, viewId: 42 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/5/views/42/buckets');
+      expect(result.content[0].text).toContain('Found 1 buckets');
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([
+            { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+          ]),
+        }),
+      );
+
+      await expect(listBuckets({ id: 5 }, authManager)).rejects.toThrow(
+        'Project 5 has no Kanban view, so it has no buckets',
+      );
+    });
+  });
+
+  describe('bucket response handling', () => {
+    it('returns an empty bucket list when the API returns an empty array', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      expect(result.content[0].text).toContain('Found 0 buckets');
+    });
+
+    it('treats a non-array bucket response as an empty list', async () => {
+      // An empty 2xx body resolves to null inside vikunjaRestRequest.
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      expect(result.content[0].text).toContain('Found 0 buckets');
+    });
+
+    it('defaults isDoneBucket to false when the field is absent', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([{ id: 100, title: 'Backlog' }]),
+        }),
+      );
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      const text = result.content[0].text;
+      expect(text).toContain('Found 1 buckets');
+      expect(text).toContain('"isDoneBucket": false');
+    });
+
+    it('passes a session id through to the response', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      const result = await listBuckets(
+        { id: 5, viewId: 11, sessionId: 'sess-9' },
+        authManager,
+      );
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Success');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates an HTTP error from the buckets request', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: 'view does not exist',
+        }),
+      );
+
+      await expect(
+        listBuckets({ id: 5, viewId: 11 }, authManager),
+      ).rejects.toThrow(MCPError);
+    });
+
+    it('propagates a network error raised while resolving the view', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('offline'));
+
+      await expect(listBuckets({ id: 5 }, authManager)).rejects.toThrow(
+        'Vikunja REST request failed (GET /projects/5/views): offline',
+      );
+    });
+  });
+});

--- a/tests/tools/tasks.test.ts
+++ b/tests/tools/tasks.test.ts
@@ -853,7 +853,7 @@ describe('Tasks Tool', () => {
 
       // Labels are updated via updateTaskLabels
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
     });
 
@@ -2569,7 +2569,7 @@ describe('Tasks Tool', () => {
       const result = await callTool('bulk-create', { projectId: 1, tasks });
 
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
       expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalledWith(1, {
         user_ids: [3, 4],

--- a/tests/tools/tasks/buckets.test.ts
+++ b/tests/tools/tasks/buckets.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the task Kanban bucket operation (`set-bucket`).
+ *
+ * Covers validation of required/optional ids, project and view auto-resolution,
+ * explicit project/view ids, and propagation of REST errors.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../../src/auth/AuthManager';
+import { setTaskBucket } from '../../../src/tools/tasks/buckets';
+import { MCPError, ErrorCode } from '../../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** Minimal Response-like object for the REST helper. */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+}): Response {
+  const { ok = true, status = 200, statusText = 'OK', text = '' } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+/** A views payload containing a Kanban view (id 11). */
+const kanbanViews = JSON.stringify([
+  { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+  { id: 11, title: 'Kanban', project_id: 5, view_kind: 'kanban' },
+]);
+
+describe('setTaskBucket', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('validation', () => {
+    it('throws a VALIDATION_ERROR when the task id is missing', async () => {
+      await expect(setTaskBucket({ bucketId: 3 }, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'Task id is required for set-bucket operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when the task id is zero (falsy)', async () => {
+      await expect(
+        setTaskBucket({ id: 0, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Task id is required for set-bucket operation');
+    });
+
+    it('throws a VALIDATION_ERROR when bucketId is undefined', async () => {
+      await expect(setTaskBucket({ id: 1 }, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'bucketId is required for set-bucket operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when bucketId is null', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: null as unknown as number }, authManager),
+      ).rejects.toThrow('bucketId is required for set-bucket operation');
+    });
+
+    it('treats a bucketId of 0 as provided and validates it as an id', async () => {
+      // bucketId 0 passes the undefined/null guard but fails validateId.
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 0 }, authManager),
+      ).rejects.toThrow('bucketId must be a positive integer');
+    });
+
+    it('throws when the task id is not a positive integer', async () => {
+      await expect(
+        setTaskBucket({ id: -2, bucketId: 3 }, authManager),
+      ).rejects.toThrow('id must be a positive integer');
+    });
+
+    it('throws when an explicit viewId is invalid', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, viewId: -1 }, authManager),
+      ).rejects.toThrow('viewId must be a positive integer');
+    });
+
+    it('throws when an explicit projectId is invalid', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, projectId: 0 }, authManager),
+      ).rejects.toThrow('projectId must be a positive integer');
+    });
+  });
+
+  describe('project and view resolution', () => {
+    it('resolves project and view ids from the API when both are omitted', async () => {
+      // 1) GET /tasks/:id  2) GET /projects/:id/views  3) POST bucket task
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 5, title: 'T' }) }),
+        )
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await setTaskBucket({ id: 1, bucketId: 3 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/tasks/1');
+      expect(urls[1]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[2]).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+
+      // The POST body carries the TaskBucket payload.
+      const [, postInit] = mockFetch.mock.calls[2] as [string, RequestInit];
+      expect(postInit.method).toBe('POST');
+      expect(postInit.body).toBe(JSON.stringify({ task_id: 1, bucket_id: 3 }));
+
+      const text = result.content[0].text;
+      expect(text).toContain('Task 1 moved to bucket 3');
+      expect(text).toContain('Success');
+    });
+
+    it('does not fetch the task when projectId is supplied explicitly', async () => {
+      // 1) GET /projects/:id/views  2) POST bucket task
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await setTaskBucket({ id: 1, bucketId: 3, projectId: 5 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[1]).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+    });
+
+    it('does not resolve the view when viewId is supplied explicitly', async () => {
+      // projectId omitted -> GET /tasks/:id, then POST (no views lookup)
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 8 }) }),
+        )
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await setTaskBucket({ id: 1, bucketId: 3, viewId: 22 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/tasks/1');
+      expect(urls[1]).toBe(
+        'https://vikunja.test/api/v1/projects/8/views/22/buckets/3/tasks',
+      );
+    });
+
+    it('issues only the bucket POST when both projectId and viewId are supplied', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await setTaskBucket(
+        { id: 1, bucketId: 3, projectId: 5, viewId: 11, sessionId: 'sess-1' },
+        authManager,
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+      expect(result.content[0].type).toBe('text');
+    });
+
+    it('throws NOT_FOUND when the task lookup returns no body', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow(
+        new MCPError(
+          ErrorCode.NOT_FOUND,
+          'Could not resolve the project of task 1',
+        ),
+      );
+    });
+
+    it('throws NOT_FOUND when the task has no numeric project_id', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ text: JSON.stringify({ id: 1, project_id: 'oops' }) }),
+      );
+
+      try {
+        await setTaskBucket({ id: 1, bucketId: 3 }, authManager);
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.NOT_FOUND);
+      }
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 5 }) }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            text: JSON.stringify([
+              { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+            ]),
+          }),
+        );
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Project 5 has no Kanban view, so it has no buckets');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates an HTTP error from the bucket POST', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: 'invalid bucket',
+        }),
+      );
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, projectId: 5, viewId: 11 }, authManager),
+      ).rejects.toThrow(MCPError);
+    });
+
+    it('propagates a network error raised while resolving the task', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Vikunja REST request failed (GET /tasks/1): network down');
+    });
+  });
+});

--- a/tests/tools/tasks/bulk-operations.test.ts
+++ b/tests/tools/tasks/bulk-operations.test.ts
@@ -299,6 +299,42 @@ describe('Bulk operations', () => {
       });
     });
 
+    describe('Labels field', () => {
+      it('should set labels via the field-preserving fallback path', async () => {
+        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTaskLabels.mockResolvedValue({});
+
+        const result = await bulkUpdateTasks({ taskIds: [1], field: 'labels', value: [3, 8] });
+
+        // labels must never go through the native /tasks/bulk endpoint
+        expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+        expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
+          labels: [{ id: 3 }, { id: 8 }],
+        });
+        expect(result.content[0].text).toContain('## ✅ Success');
+      });
+
+      it('should coerce a stringified labels array', async () => {
+        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTaskLabels.mockResolvedValue({});
+
+        const result = await bulkUpdateTasks({ taskIds: [1], field: 'labels', value: '[3, 8]' });
+
+        expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
+          labels: [{ id: 3 }, { id: 8 }],
+        });
+        expect(result.content[0].text).toContain('## ✅ Success');
+      });
+
+      it('should reject a labels value that is not a list of numbers', async () => {
+        await expect(
+          bulkUpdateTasks({ taskIds: [1], field: 'labels', value: 'not-a-list' }),
+        ).rejects.toThrow('labels must be an array of numbers');
+      });
+    });
+
     describe('Error handling', () => {
       it('should preserve MCPError instances', async () => {
         const mcpError = new MCPError(ErrorCode.NOT_FOUND, 'Task not found');
@@ -524,7 +560,7 @@ describe('Bulk operations', () => {
         });
 
         expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
-          label_ids: [1],
+          labels: [{ id: 1 }],
         });
         expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalledWith(1, {
           user_ids: [1],

--- a/tests/tools/tasks/labels.test.ts
+++ b/tests/tools/tasks/labels.test.ts
@@ -18,6 +18,7 @@ describe('Label operations', () => {
       addLabelToTask: jest.fn(),
       removeLabelFromTask: jest.fn(),
       getTask: jest.fn(),
+      getTaskLabels: jest.fn(),
     },
   };
 
@@ -25,6 +26,8 @@ describe('Label operations', () => {
     // Use resetAllMocks to also reset mock implementations (not just call history)
     jest.resetAllMocks();
     mockGetClientFromContext.mockResolvedValue(mockClient as any);
+    // Default: task has no labels yet
+    mockClient.tasks.getTaskLabels.mockResolvedValue([]);
   });
 
   describe('applyLabels', () => {
@@ -65,6 +68,52 @@ describe('Label operations', () => {
 
       expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledTimes(2);
       expect(result.content[0].text).toContain('Labels applied to task successfully');
+    });
+
+    it('should skip labels already present on the task', async () => {
+      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      // Label 1 is already on the task; only label 2 should be applied.
+      mockClient.tasks.getTaskLabels.mockResolvedValue([{ id: 1, title: 'research' }]);
+      mockClient.tasks.addLabelToTask.mockResolvedValue({});
+      mockClient.tasks.getTask.mockResolvedValue(mockTask);
+
+      const result = await applyLabels({ id: 1, labels: [1, 2] });
+
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledTimes(1);
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledWith(1, {
+        task_id: 1,
+        label_id: 2,
+      });
+      expect(result.content[0].text).toContain('already present');
+    });
+
+    it('should not abort when a label is already on the task', async () => {
+      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      // getTaskLabels reports nothing, but addLabelToTask races and rejects
+      // the first label as a duplicate; the rest must still be applied.
+      mockClient.tasks.addLabelToTask
+        .mockRejectedValueOnce(new Error('This label already exists on the task'))
+        .mockResolvedValueOnce({});
+      mockClient.tasks.getTask.mockResolvedValue(mockTask);
+
+      const result = await applyLabels({ id: 1, labels: [1, 2] });
+
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledTimes(2);
+      expect(result.content[0].text).toContain('Label applied to task successfully');
+    });
+
+    it('should report when every requested label is already present', async () => {
+      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      mockClient.tasks.getTaskLabels.mockResolvedValue([
+        { id: 1, title: 'research' },
+        { id: 2, title: 'ops' },
+      ]);
+      mockClient.tasks.getTask.mockResolvedValue(mockTask);
+
+      const result = await applyLabels({ id: 1, labels: [1, 2] });
+
+      expect(mockClient.tasks.addLabelToTask).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain('No labels applied');
     });
 
     it('should handle API errors gracefully', async () => {
@@ -108,16 +157,15 @@ describe('Label operations', () => {
 
   describe('listTaskLabels', () => {
     it('should list labels for a task successfully', async () => {
-      const mockTask = {
-        id: 1,
-        title: 'Test Task',
-        labels: [{ id: 1, title: 'research', hex_color: '3498db' }],
-      };
+      const mockTask = { id: 1, title: 'Test Task' };
+      mockClient.tasks.getTaskLabels.mockResolvedValue([
+        { id: 1, title: 'research', hex_color: '3498db' },
+      ]);
       mockClient.tasks.getTask.mockResolvedValue(mockTask);
 
       const result = await listTaskLabels({ id: 1 });
 
-      expect(mockClient.tasks.getTask).toHaveBeenCalledWith(1);
+      expect(mockClient.tasks.getTaskLabels).toHaveBeenCalledWith(1);
       expect(result.content[0].text).toContain('Task has 1 label(s)');
     });
 
@@ -126,7 +174,8 @@ describe('Label operations', () => {
     });
 
     it('should handle task with no labels', async () => {
-      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      const mockTask = { id: 1, title: 'Test Task' };
+      mockClient.tasks.getTaskLabels.mockResolvedValue([]);
       mockClient.tasks.getTask.mockResolvedValue(mockTask);
 
       const result = await listTaskLabels({ id: 1 });

--- a/tests/tools/templates.test.ts
+++ b/tests/tools/templates.test.ts
@@ -1172,7 +1172,7 @@ describe('Templates Tool', () => {
       });
 
       // Should use 0 as fallback for null task ID
-      expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(0, { label_ids: [1, 2] });
+      expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(0, { labels: [{ id: 1 }, { id: 2 }] });
     });
 
     it('should handle variable names with regex special characters', async () => {

--- a/tests/utils/label-bulk.test.ts
+++ b/tests/utils/label-bulk.test.ts
@@ -1,0 +1,30 @@
+import { setTaskLabels } from '../../src/utils/label-bulk';
+
+describe('setTaskLabels', () => {
+  it('sends the { labels: [{ id }] } body shape that Vikunja requires', async () => {
+    const updateTaskLabels = jest.fn().mockResolvedValue({});
+    const client = { tasks: { updateTaskLabels } };
+
+    await setTaskLabels(client as never, 42, [3, 8]);
+
+    expect(updateTaskLabels).toHaveBeenCalledWith(42, {
+      labels: [{ id: 3 }, { id: 8 }],
+    });
+  });
+
+  it('sends an empty labels array to clear every label', async () => {
+    const updateTaskLabels = jest.fn().mockResolvedValue({});
+    const client = { tasks: { updateTaskLabels } };
+
+    await setTaskLabels(client as never, 7, []);
+
+    expect(updateTaskLabels).toHaveBeenCalledWith(7, { labels: [] });
+  });
+
+  it('propagates errors from the API client', async () => {
+    const updateTaskLabels = jest.fn().mockRejectedValue(new Error('boom'));
+    const client = { tasks: { updateTaskLabels } };
+
+    await expect(setTaskLabels(client as never, 1, [1])).rejects.toThrow('boom');
+  });
+});

--- a/tests/utils/vikunja-rest.test.ts
+++ b/tests/utils/vikunja-rest.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the direct Vikunja REST helper.
+ *
+ * Covers vikunjaRestRequest (URL normalization, body handling, HTTP errors,
+ * network errors, empty/non-JSON bodies) and resolveKanbanViewId.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../src/auth/AuthManager';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../src/utils/vikunja-rest';
+import { MCPError, ErrorCode } from '../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/**
+ * Builds a minimal Response-like object good enough for vikunjaRestRequest,
+ * which only reads `.ok`, `.status`, `.statusText` and `.text()`.
+ */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+  textThrows?: boolean;
+}): Response {
+  const {
+    ok = true,
+    status = 200,
+    statusText = 'OK',
+    text = '',
+    textThrows = false,
+  } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: textThrows
+      ? jest.fn(async () => {
+          throw new Error('stream read error');
+        })
+      : jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+describe('vikunja-rest helper', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('vikunjaRestRequest', () => {
+    it('performs a GET request and parses the JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify({ id: 7 }) }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/tasks/7');
+
+      expect(result).toEqual({ id: 7 });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      // apiUrl had no /api/v1 prefix, so it must have been appended.
+      expect(url).toBe('https://vikunja.test/api/v1/tasks/7');
+      expect(init.method).toBe('GET');
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        'Bearer tk_test-token',
+      );
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+        'application/json',
+      );
+      // No body when none is supplied.
+      expect(init.body).toBeUndefined();
+    });
+
+    it('serializes the body as JSON when one is provided', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await vikunjaRestRequest(authManager, 'POST', '/things', { a: 1 });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ a: 1 }));
+    });
+
+    it('does not normalize an apiUrl that already includes the /api/v1 prefix', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/api/v1', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects/4/views');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/4/views');
+    });
+
+    it('strips a trailing slash from the apiUrl before building the URL', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects');
+    });
+
+    it('recognizes an /api/v2 versioned root', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/api/v2', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v2/projects');
+    });
+
+    it('returns null when the response body is empty', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/empty');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the response body is not valid JSON', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: 'not json at all' }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/weird');
+
+      expect(result).toBeNull();
+    });
+
+    it('throws an MCPError when fetch rejects (network error)', async () => {
+      // Persistent rejection: this test makes two assertion calls.
+      mockFetch.mockRejectedValue(new Error('connection refused'));
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(MCPError);
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): connection refused',
+      );
+    });
+
+    it('includes the error code API_ERROR on network failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('boom'));
+
+      try {
+        await vikunjaRestRequest(authManager, 'GET', '/tasks/1');
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.API_ERROR);
+      }
+    });
+
+    it('stringifies a non-Error rejection value', async () => {
+      mockFetch.mockRejectedValueOnce('plain string failure');
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): plain string failure',
+      );
+    });
+
+    it('throws an MCPError with the response detail when the response is not OK', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: 'task does not exist',
+        }),
+      );
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/999'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/999): HTTP 404 Not Found — task does not exist',
+      );
+    });
+
+    it('omits the detail suffix when the error body is empty', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          text: '',
+        }),
+      );
+
+      try {
+        await vikunjaRestRequest(authManager, 'POST', '/things');
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect((error as MCPError).message).toBe(
+          'Vikunja REST request failed (POST /things): HTTP 500 Internal Server Error',
+        );
+      }
+    });
+
+    it('truncates an oversized error body to 500 characters', async () => {
+      const longBody = 'x'.repeat(2000);
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: longBody,
+        }),
+      );
+
+      try {
+        await vikunjaRestRequest(authManager, 'GET', '/tasks/1');
+        throw new Error('should have thrown');
+      } catch (error) {
+        const message = (error as MCPError).message;
+        // 500 chars of 'x' should be present, but not the full 2000.
+        expect(message).toContain('x'.repeat(500));
+        expect(message).not.toContain('x'.repeat(501));
+      }
+    });
+
+    it('falls back to the status line when the error body cannot be read', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 502,
+          statusText: 'Bad Gateway',
+          textThrows: true,
+        }),
+      );
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): HTTP 502 Bad Gateway',
+      );
+    });
+  });
+
+  describe('resolveKanbanViewId', () => {
+    it('returns the id of the Kanban view when one exists', async () => {
+      const views = [
+        { id: 10, title: 'List', project_id: 4, view_kind: 'list' },
+        { id: 11, title: 'Kanban', project_id: 4, view_kind: 'kanban' },
+        { id: 12, title: 'Gantt', project_id: 4, view_kind: 'gantt' },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify(views) }));
+
+      const viewId = await resolveKanbanViewId(authManager, 4);
+
+      expect(viewId).toBe(11);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/4/views');
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      const views = [{ id: 10, title: 'List', project_id: 4, view_kind: 'list' }];
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify(views) }));
+
+      await expect(resolveKanbanViewId(authManager, 4)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.NOT_FOUND,
+          'Project 4 has no Kanban view, so it has no buckets',
+        ),
+      );
+    });
+
+    it('throws NOT_FOUND when the views response is not an array', async () => {
+      // A 2xx non-JSON body resolves to null inside vikunjaRestRequest.
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      try {
+        await resolveKanbanViewId(authManager, 9);
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.NOT_FOUND);
+        expect((error as MCPError).message).toBe(
+          'Project 9 has no Kanban view, so it has no buckets',
+        );
+      }
+    });
+
+    it('propagates an MCPError raised by the underlying request', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ ok: false, status: 403, statusText: 'Forbidden', text: 'nope' }),
+      );
+
+      await expect(resolveKanbanViewId(authManager, 4)).rejects.toThrow(MCPError);
+    });
+  });
+});


### PR DESCRIPTION
## What

Task labels were not persisted reliably by the tasks tool. Root causes:

1. `withRetry` (`src/utils/retry.ts`) wrapped every operation in an opossum circuit breaker cached under the fixed name `'anonymous'`. Opossum binds the action at construction time, so every later call re-ran the first closure instead of its own. It now runs the operation directly.
2. `updateTaskLabels` sent `{label_ids: [...]}`, which Vikunja silently ignores (HTTP 201, nothing persisted); it requires `{labels: [{id}]}`. A new helper `setTaskLabels` in `src/utils/label-bulk.ts` sends the correct body. `create`, `update`, `apply-label`, `bulk`, `batch-import` and `templates` all route through it.
3. `apply-label` with multiple ids applied only the first and aborted on "already exists"; `list-labels` read the unreliable embedded `labels` array. Both now use the dedicated `GET /tasks/{id}/labels` endpoint and tolerate idempotent re-application.

## Notes

Stacked on #47. Until #47 merges this PR's diff also shows its commits; review only `d47514a`, `41f2ea4`, `fb2ebd7`.

Verified end to end against a live Vikunja v2.3.0 instance.