### PR TITLE
fix: stop sanitizeString rejecting and escaping valid task content

### DIFF
--- a/src/services/TaskCreationService.ts
+++ b/src/services/TaskCreationService.ts
@@ -2,6 +2,7 @@ import { logger } from '../utils/logger';
 import type { TaskCreationData } from '../types';
 import { MCPError, ErrorCode } from '../types';
 import { isAuthenticationError } from '../utils/auth-error-handler';
+import { setTaskLabels } from '../utils/label-bulk';
 import type { Task, Label, User } from 'node-vikunja';
 import type { TypedVikunjaClient } from '../types/node-vikunja-extended';
 import type { ImportedTask } from '../parsers/InputParserFactory';
@@ -267,9 +268,7 @@ export class TaskCreationService {
     if (labelIds.length > 0 && createdTask.id) {
       try {
         // Try to update labels
-        const updateResult = await client.tasks.updateTaskLabels(createdTask.id, {
-          label_ids: labelIds,
-        });
+        await setTaskLabels(client, createdTask.id, labelIds);
 
         // Verify the labels were actually assigned (API tokens may silently fail)
         const labelsActuallyAssigned = await this.verifyLabelAssignment(client, createdTask.id, labelIds);
@@ -280,7 +279,6 @@ export class TaskCreationService {
             taskId: createdTask.id,
             labelIds,
             labelNames: task.labels,
-            updateResult,
           });
           warnings.push(`Labels specified but not assigned (API token limitation). Consider using JWT authentication for label support.`);
         } else {

--- a/src/tools/projects/buckets.ts
+++ b/src/tools/projects/buckets.ts
@@ -1,0 +1,95 @@
+/**
+ * Project Kanban bucket operations
+ *
+ * Implements `list-buckets`, which returns the buckets (columns) of a
+ * project's Kanban view. This lets callers resolve a bucket by name (e.g.
+ * "Doing") instead of hard-coding numeric bucket ids.
+ *
+ * node-vikunja does not expose the Kanban view endpoints, so this calls the
+ * Vikunja REST API directly via the shared `vikunja-rest` helper.
+ */
+
+import type { AuthManager } from '../../auth/AuthManager';
+import { MCPError, ErrorCode } from '../../types';
+import { validateId } from '../../utils/validation';
+import { createStandardResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../utils/vikunja-rest';
+
+export interface ListBucketsArgs {
+  /** Project whose Kanban buckets should be listed. */
+  id?: number;
+  /** Optional Kanban view id. Auto-resolved from the project when omitted. */
+  viewId?: number;
+  /** Session id for response tracking. */
+  sessionId?: string;
+}
+
+interface VikunjaBucket {
+  id: number;
+  title: string;
+  project_view_id?: number;
+  position?: number;
+  limit?: number;
+  is_done_bucket?: boolean;
+}
+
+/**
+ * Lists the Kanban buckets of a project.
+ *
+ * @param args - Project id and optional view id
+ * @param authManager - Active auth manager holding session credentials
+ * @returns MCP response containing the project's Kanban buckets
+ */
+export async function listBuckets(
+  args: ListBucketsArgs,
+  authManager: AuthManager,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  if (!args.id) {
+    throw new MCPError(
+      ErrorCode.VALIDATION_ERROR,
+      'Project id is required for list-buckets operation',
+    );
+  }
+  validateId(args.id, 'id');
+  if (args.viewId !== undefined) validateId(args.viewId, 'viewId');
+
+  const viewId =
+    args.viewId !== undefined ? args.viewId : await resolveKanbanViewId(authManager, args.id);
+
+  const buckets = await vikunjaRestRequest<VikunjaBucket[]>(
+    authManager,
+    'GET',
+    `/projects/${args.id}/views/${viewId}/buckets`,
+  );
+  const bucketList = Array.isArray(buckets) ? buckets : [];
+
+  const response = createStandardResponse(
+    'list-buckets',
+    `Found ${bucketList.length} buckets in the Kanban view of project ${args.id}`,
+    {
+      projectId: args.id,
+      viewId,
+      buckets: bucketList.map((bucket) => ({
+        id: bucket.id,
+        title: bucket.title,
+        position: bucket.position,
+        limit: bucket.limit,
+        isDoneBucket: bucket.is_done_bucket ?? false,
+      })),
+    },
+    {
+      timestamp: new Date().toISOString(),
+      count: bucketList.length,
+    },
+    args.sessionId,
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: formatAorpAsMarkdown(response),
+      },
+    ],
+  };
+}

--- a/src/tools/projects/index.ts
+++ b/src/tools/projects/index.ts
@@ -53,6 +53,8 @@ import {
   type AuthShareArgs
 } from './sharing';
 
+import { listBuckets, type ListBucketsArgs } from './buckets';
+
 /**
  * Legacy single-tool interface for backward compatibility
  * Registers a single tool with all subcommands like the original implementation
@@ -64,11 +66,12 @@ export function registerProjectsTool(
 ): void {
   server.tool(
     'vikunja_projects',
-    'Manage projects with full CRUD operations, hierarchy management, and sharing capabilities',
+    'Manage projects with full CRUD operations, hierarchy management, sharing capabilities, and Kanban bucket listing',
     {
       subcommand: z.enum(['list', 'get', 'create', 'update', 'delete', 'archive', 'unarchive',
         'get-children', 'get-tree', 'get-breadcrumb', 'move',
-        'create-share', 'list-shares', 'get-share', 'delete-share', 'auth-share'
+        'create-share', 'list-shares', 'get-share', 'delete-share', 'auth-share',
+        'list-buckets'
       ]),
       // CRUD arguments
       id: z.number().positive().optional(),
@@ -83,6 +86,8 @@ export function registerProjectsTool(
       // Hierarchy arguments
       maxDepth: z.number().min(1).max(20).optional(),
       includeArchived: z.boolean().optional(),
+      // Kanban bucket arguments (list-buckets subcommand)
+      viewId: z.number().positive().optional(),
       // Sharing arguments
       projectId: z.number().positive().optional(),
       shareId: z.string().optional(),
@@ -218,6 +223,14 @@ export function registerProjectsTool(
             if (args.password !== undefined) authShareArgs.password = args.password;
             return await authProjectShare(authShareArgs);
           }
+
+          // Kanban bucket operations
+          case 'list-buckets':
+            if (!args.id) {
+              throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Project ID is required for list-buckets operation');
+            }
+            validateId(args.id, 'id');
+            return await listBuckets(args as ListBucketsArgs, authManager);
 
           default:
             throw new MCPError(ErrorCode.VALIDATION_ERROR, `Unknown subcommand: ${String(args.subcommand)}`);

--- a/src/tools/projects/index.ts
+++ b/src/tools/projects/index.ts
@@ -86,8 +86,10 @@ export function registerProjectsTool(
       // Hierarchy arguments
       maxDepth: z.number().min(1).max(20).optional(),
       includeArchived: z.boolean().optional(),
-      // Kanban bucket arguments (list-buckets subcommand)
-      viewId: z.number().positive().optional(),
+      // Kanban bucket arguments (list-buckets subcommand).
+      // z.coerce tolerates MCP clients whose cached tool schema predates
+      // this param and therefore send it as a string over JSON-RPC.
+      viewId: z.coerce.number().positive().optional(),
       // Sharing arguments
       projectId: z.number().positive().optional(),
       shareId: z.string().optional(),

--- a/src/tools/tasks/buckets.ts
+++ b/src/tools/tasks/buckets.ts
@@ -1,0 +1,121 @@
+/**
+ * Task Kanban bucket operations
+ *
+ * Implements `set-bucket`, which moves a task into a Kanban bucket (column)
+ * of its project's Kanban view. This is the operation behind a "move card to
+ * the Doing column" workflow.
+ *
+ * node-vikunja does not expose the Kanban view endpoints, so this calls the
+ * Vikunja REST API directly via the shared `vikunja-rest` helper.
+ */
+
+import type { AuthManager } from '../../auth/AuthManager';
+import { MCPError, ErrorCode } from '../../types';
+import { validateId } from '../../utils/validation';
+import { createStandardResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../utils/vikunja-rest';
+
+export interface SetTaskBucketArgs {
+  /** Id of the task to move. */
+  id?: number;
+  /** Id of the destination Kanban bucket. */
+  bucketId?: number;
+  /** Optional Kanban view id. Auto-resolved from the project when omitted. */
+  viewId?: number;
+  /** Optional project id. Auto-resolved from the task when omitted. */
+  projectId?: number;
+  /** Session id for response tracking. */
+  sessionId?: string;
+}
+
+interface VikunjaTaskSummary {
+  id: number;
+  project_id: number;
+  title?: string;
+}
+
+/**
+ * Moves a task into a Kanban bucket.
+ *
+ * Resolution order when optional ids are omitted:
+ *  - projectId: fetched from the task itself
+ *  - viewId: resolved to the project's Kanban view
+ *
+ * @param args - Task id, destination bucket id, and optional view/project ids
+ * @param authManager - Active auth manager holding session credentials
+ * @returns MCP response describing the move
+ */
+export async function setTaskBucket(
+  args: SetTaskBucketArgs,
+  authManager: AuthManager,
+): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+  if (!args.id) {
+    throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Task id is required for set-bucket operation');
+  }
+  if (args.bucketId === undefined || args.bucketId === null) {
+    throw new MCPError(
+      ErrorCode.VALIDATION_ERROR,
+      'bucketId is required for set-bucket operation',
+    );
+  }
+  validateId(args.id, 'id');
+  validateId(args.bucketId, 'bucketId');
+  if (args.viewId !== undefined) validateId(args.viewId, 'viewId');
+  if (args.projectId !== undefined) validateId(args.projectId, 'projectId');
+
+  // Resolve the project id from the task when the caller did not supply it.
+  let projectId = args.projectId;
+  if (projectId === undefined) {
+    const task = await vikunjaRestRequest<VikunjaTaskSummary>(
+      authManager,
+      'GET',
+      `/tasks/${args.id}`,
+    );
+    if (!task || typeof task.project_id !== 'number') {
+      throw new MCPError(
+        ErrorCode.NOT_FOUND,
+        `Could not resolve the project of task ${args.id}`,
+      );
+    }
+    projectId = task.project_id;
+  }
+
+  // Resolve the Kanban view id when the caller did not supply it.
+  const viewId =
+    args.viewId !== undefined ? args.viewId : await resolveKanbanViewId(authManager, projectId);
+
+  // Place the task into the bucket. Vikunja's bucket-task endpoint expects the
+  // TaskBucket payload; bucket_id is also part of the URL but is sent in the
+  // body as the API model requires it.
+  await vikunjaRestRequest(
+    authManager,
+    'POST',
+    `/projects/${projectId}/views/${viewId}/buckets/${args.bucketId}/tasks`,
+    { task_id: args.id, bucket_id: args.bucketId },
+  );
+
+  const response = createStandardResponse(
+    'set-task-bucket',
+    `Task ${args.id} moved to bucket ${args.bucketId}`,
+    {
+      taskId: args.id,
+      bucketId: args.bucketId,
+      viewId,
+      projectId,
+    },
+    {
+      timestamp: new Date().toISOString(),
+      affectedFields: ['bucket_id'],
+    },
+    args.sessionId,
+  );
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: formatAorpAsMarkdown(response),
+      },
+    ],
+  };
+}

--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -100,6 +100,15 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
 
     try {
       if (!args.field) throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Field required');
+
+      // The native Vikunja bulk endpoint truncates fields it does not receive
+      // (description, priority, ...) when moving tasks across projects, which
+      // silently corrupts task data. Route project_id moves through the
+      // field-preserving per-task path (getTask + merge + updateTask) instead.
+      if (args.field === 'project_id') {
+        return await updateWithFallback();
+      }
+
       const bulkOp = { task_ids: taskIds, field: args.field, value: args.value };
       if (args.field === 'repeat_mode' && typeof args.value === 'string') {
         bulkOp.value = REPEAT_MODE_MAP[args.value] ?? args.value;

--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -6,6 +6,7 @@
 import { MCPError, ErrorCode, createStandardResponse, getClientFromContext, logger, isAuthenticationError, RETRY_CONFIG, transformApiError, handleFetchError } from '../../index';
 import type { Assignee } from '../../types';
 import { withRetry } from '../../utils/retry';
+import { setTaskLabels } from '../../utils/label-bulk';
 import { BatchProcessor } from '../../utils/performance/batch-processor';
 import type { Task } from 'node-vikunja';
 import { convertRepeatConfiguration, applyFieldUpdate } from './validation';
@@ -79,7 +80,7 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
           }
         }
         if (args.field === 'labels' && Array.isArray(args.value)) {
-          await withRetry(() => client.tasks.updateTaskLabels(taskId, { label_ids: args.value as number[] }), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
+          await withRetry(() => setTaskLabels(client, taskId, args.value as number[]), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
         }
         return updated;
       });
@@ -101,11 +102,12 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
     try {
       if (!args.field) throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Field required');
 
-      // The native Vikunja bulk endpoint truncates fields it does not receive
-      // (description, priority, ...) when moving tasks across projects, which
-      // silently corrupts task data. Route project_id moves through the
-      // field-preserving per-task path (getTask + merge + updateTask) instead.
-      if (args.field === 'project_id') {
+      // The native Vikunja bulk endpoint does not apply label relations and,
+      // for project_id moves, truncates fields it does not receive
+      // (description, priority, ...), silently corrupting task data. Route
+      // both through the field-preserving per-task path (getTask + merge +
+      // updateTask, plus a dedicated /labels/bulk call for labels) instead.
+      if (args.field === 'project_id' || args.field === 'labels') {
         return await updateWithFallback();
       }
 
@@ -228,7 +230,7 @@ export async function bulkCreateTasks(args: BulkCreateArgs): Promise<{ content: 
 
         try {
           const labels = t.labels;
-          if (labels && labels.length > 0) await withRetry(() => client.tasks.updateTaskLabels(createdId, { label_ids: labels }), { maxRetries: RETRY_CONFIG.AUTH_ERRORS.maxRetries ?? 3, timeout: (RETRY_CONFIG.AUTH_ERRORS.initialDelay ?? 1000) + (RETRY_CONFIG.AUTH_ERRORS.maxDelay ?? 10000), shouldRetry: isAuthenticationError });
+          if (labels && labels.length > 0) await withRetry(() => setTaskLabels(client, createdId, labels), { maxRetries: RETRY_CONFIG.AUTH_ERRORS.maxRetries ?? 3, timeout: (RETRY_CONFIG.AUTH_ERRORS.initialDelay ?? 1000) + (RETRY_CONFIG.AUTH_ERRORS.maxDelay ?? 10000), shouldRetry: isAuthenticationError });
           const assignees = t.assignees;
           if (assignees && assignees.length > 0) {
             try {

--- a/src/tools/tasks/bulk/BulkOperationValidator.ts
+++ b/src/tools/tasks/bulk/BulkOperationValidator.ts
@@ -33,6 +33,54 @@ export interface BulkCreateArgs {
 }
 
 /**
+ * Coerce a labels/assignees value into a number array.
+ *
+ * The bulk-update `value` field is loosely typed (z.unknown), and an MCP
+ * client with a stale cached schema may send the array as a JSON string
+ * ("[3,8]") or a comma-separated string ("3,8") instead of a real array.
+ * Returns the value unchanged when it cannot be coerced, so that
+ * validateFieldConstraints still reports a clear error.
+ */
+function coerceToNumberArray(value: unknown): unknown {
+  const toNumbers = (arr: unknown[]): unknown[] =>
+    arr.map((item) =>
+      typeof item === 'string' && item.trim() !== '' && !Number.isNaN(Number(item))
+        ? Number(item)
+        : item,
+    );
+
+  if (Array.isArray(value)) {
+    return toNumbers(value);
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return value;
+    }
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return toNumbers(parsed);
+        }
+      } catch {
+        // Not valid JSON; fall through to comma-separated handling.
+      }
+    }
+    const parts = trimmed
+      .split(',')
+      .map((part) => part.trim())
+      .filter((part) => part !== '');
+    if (parts.length > 0 && parts.every((part) => !Number.isNaN(Number(part)))) {
+      return parts.map((part) => Number(part));
+    }
+  }
+
+  return value;
+}
+
+/**
  * Validator for bulk update operations
  */
 export const bulkOperationValidator = {
@@ -84,6 +132,13 @@ export const bulkOperationValidator = {
       if (!isNaN(numValue)) {
         args.value = numValue;
       }
+    }
+
+    // labels and assignees expect a number[]; coerce a stringified array
+    // ("[3,8]" or "3,8") that a stale client schema may send so a valid
+    // value is not rejected as "must be an array of numbers".
+    if (args.field && ['labels', 'assignees'].includes(args.field)) {
+      args.value = coerceToNumberArray(args.value);
     }
   },
 

--- a/src/tools/tasks/crud/TaskCreationService.ts
+++ b/src/tools/tasks/crud/TaskCreationService.ts
@@ -9,6 +9,7 @@ import type { Task, VikunjaClient } from 'node-vikunja';
 import { logger } from '../../../utils/logger';
 import { isAuthenticationError } from '../../../utils/auth-error-handler';
 import { withRetry, RETRY_CONFIG } from '../../../utils/retry';
+import { setTaskLabels } from '../../../utils/label-bulk';
 import { transformApiError, handleFetchError } from '../../../utils/error-handler';
 import { sanitizeString } from '../../../utils/validation';
 import { AUTH_ERROR_MESSAGES } from '../constants';
@@ -131,8 +132,12 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
       {
         timestamp: new Date().toISOString(),
         projectId: args.projectId,
-        labelsAdded: args.labels ? args.labels.length > 0 : false,
-        assigneesAdded: args.assignees ? args.assignees.length > 0 : false,
+        // Reflect what was actually persisted, not merely what was requested:
+        // if label/assignee attachment fails the task creation is rolled back
+        // and this response is never reached, so these flags are only true
+        // once the corresponding step has genuinely succeeded.
+        labelsAdded: creationState.labelsAdded,
+        assigneesAdded: creationState.assigneesAdded,
       },
       undefined, // verbosity (ignored - using standard AORP)
       undefined, // useOptimizedFormat (ignored - using standard AORP)
@@ -180,9 +185,7 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
 async function addLabelsToTask(client: VikunjaClient, taskId: number, labelIds: number[]): Promise<void> {
   try {
     await withRetry(
-      () => client.tasks.updateTaskLabels(taskId, {
-        label_ids: labelIds,
-      }),
+      () => setTaskLabels(client, taskId, labelIds),
       {
         ...RETRY_CONFIG.AUTH_ERRORS,
         shouldRetry: (error) => isAuthenticationError(error)

--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -18,6 +18,7 @@ export interface UpdateTaskArgs {
   id?: number;
   title?: string;
   description?: string;
+  projectId?: number;
   dueDate?: string;
   priority?: number;
   done?: boolean;
@@ -132,6 +133,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   const previousState: Record<string, unknown> = {};
   if (currentTask.title !== undefined) previousState.title = currentTask.title;
   if (currentTask.description !== undefined) previousState.description = currentTask.description;
+  if (currentTask.project_id !== undefined) previousState.project_id = currentTask.project_id;
   if (currentTask.due_date !== undefined) previousState.due_date = currentTask.due_date;
   if (currentTask.priority !== undefined) previousState.priority = currentTask.priority;
   if (currentTask.done !== undefined) previousState.done = currentTask.done;
@@ -143,6 +145,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
 
   if (args.title !== undefined && args.title !== currentTask.title) affectedFields.push('title');
   if (args.description !== undefined && args.description !== currentTask.description) affectedFields.push('description');
+  if (args.projectId !== undefined && args.projectId !== currentTask.project_id) affectedFields.push('projectId');
   if (args.dueDate !== undefined && args.dueDate !== currentTask.due_date) affectedFields.push('dueDate');
   if (args.priority !== undefined && args.priority !== currentTask.priority) affectedFields.push('priority');
   if (args.done !== undefined && args.done !== currentTask.done) affectedFields.push('done');
@@ -168,6 +171,7 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
     // Override with any provided updates
     ...(args.title !== undefined && { title: args.title }),
     ...(args.description !== undefined && { description: args.description }),
+    ...(args.projectId !== undefined && { project_id: args.projectId }),
     ...(args.dueDate !== undefined && { due_date: args.dueDate }),
     ...(args.priority !== undefined && { priority: args.priority }),
     ...(args.done !== undefined && { done: args.done }),

--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -9,6 +9,7 @@ import type { Task, VikunjaClient } from 'node-vikunja';
 import { validateDateString, validateId, convertRepeatConfiguration } from '../validation';
 import { isAuthenticationError } from '../../../utils/auth-error-handler';
 import { RETRY_CONFIG } from '../../../utils/retry';
+import { setTaskLabels } from '../../../utils/label-bulk';
 import { transformApiError, handleFetchError, handleStatusCodeError } from '../../../utils/error-handler';
 import { AUTH_ERROR_MESSAGES } from '../constants';
 import { createTaskResponse } from './TaskResponseFormatter';
@@ -199,9 +200,7 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
  */
 async function updateTaskLabels(client: VikunjaClient, taskId: number, labelIds: number[]): Promise<void> {
   try {
-    await client.tasks.updateTaskLabels(taskId, {
-      label_ids: labelIds,
-    });
+    await setTaskLabels(client, taskId, labelIds);
   } catch (labelError) {
     // Check if it's an auth error
     if (isAuthenticationError(labelError)) {

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -157,9 +157,11 @@ export function registerTasksTool(
       priority: z.number().min(0).max(5).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
-      // Kanban bucket fields (set-bucket subcommand)
-      bucketId: z.number().optional(),
-      viewId: z.number().optional(),
+      // Kanban bucket fields (set-bucket subcommand).
+      // z.coerce tolerates MCP clients whose cached tool schema predates
+      // these params and therefore send them as strings over JSON-RPC.
+      bucketId: z.coerce.number().optional(),
+      viewId: z.coerce.number().optional(),
       // Recurring task fields
       repeatAfter: z.number().min(0).optional(),
       repeatMode: z.enum(['day', 'week', 'month', 'year']).optional(),

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -25,6 +25,7 @@ import { assignUsers, unassignUsers, listAssignees } from './assignees';
 import { handleComment } from './comments';
 import { addReminder, removeReminder, listReminders } from './reminders';
 import { applyLabels, removeLabels, listTaskLabels } from './labels';
+import { setTaskBucket } from './buckets';
 
 
 /**
@@ -121,7 +122,7 @@ export function registerTasksTool(
 ): void {
   server.tool(
     'vikunja_tasks',
-    'Manage tasks with comprehensive operations (create, update, delete, list, assign, attach files, comment, bulk operations)',
+    'Manage tasks with comprehensive operations (create, update, delete, list, assign, attach files, comment, bulk operations, set Kanban bucket)',
     {
       subcommand: z.enum([
         'create',
@@ -146,6 +147,7 @@ export function registerTasksTool(
         'apply-label',
         'remove-label',
         'list-labels',
+        'set-bucket',
       ]),
       // Task creation/update fields
       title: z.string().optional(),
@@ -155,6 +157,9 @@ export function registerTasksTool(
       priority: z.number().min(0).max(5).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
+      // Kanban bucket fields (set-bucket subcommand)
+      bucketId: z.number().optional(),
+      viewId: z.number().optional(),
       // Recurring task fields
       repeatAfter: z.number().min(0).optional(),
       repeatMode: z.enum(['day', 'week', 'month', 'year']).optional(),
@@ -286,6 +291,9 @@ export function registerTasksTool(
 
           case 'list-labels':
             return listTaskLabels(args as Parameters<typeof listTaskLabels>[0]);
+
+          case 'set-bucket':
+            return setTaskBucket(args as Parameters<typeof setTaskBucket>[0], authManager);
 
           default:
             throw new MCPError(

--- a/src/tools/tasks/labels.ts
+++ b/src/tools/tasks/labels.ts
@@ -11,7 +11,23 @@ import { validateId } from './validation';
 import { createSimpleResponse, formatAorpAsMarkdown } from '../../utils/response-factory';
 
 /**
+ * Detects Vikunja's "label already exists on the task" response so that a
+ * duplicate label can be treated as a no-op rather than a fatal error.
+ */
+function isLabelAlreadyOnTaskError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.message.toLowerCase().includes('already exists');
+}
+
+/**
  * Add labels to a task
+ *
+ * Idempotent: labels already on the task are skipped instead of aborting the
+ * whole operation. Vikunja rejects a duplicate label with "label already
+ * exists on the task"; treating that as fatal previously stopped the loop and
+ * left the remaining requested labels unapplied.
  */
 export async function applyLabels(args: {
   id?: number;
@@ -35,10 +51,35 @@ export async function applyLabels(args: {
 
     const client = await getClientFromContext();
     const taskId = args.id;
-    const labelIds = args.labels;
+    // Deduplicate so a repeated id is not applied or counted twice
+    const requestedLabelIds = [...new Set(args.labels)];
 
-    // Add labels to the task with retry logic
-    for (const labelId of labelIds) {
+    // Skip labels already on the task: applying a duplicate makes Vikunja
+    // reject the request, so pre-filtering keeps the operation idempotent.
+    const alreadyPresent: number[] = [];
+    let toApply = requestedLabelIds;
+    try {
+      const currentLabels = await client.tasks.getTaskLabels(taskId);
+      const existingIds = new Set(
+        (Array.isArray(currentLabels) ? currentLabels : [])
+          .map((label) => label.id)
+          .filter((id): id is number => typeof id === 'number'),
+      );
+      toApply = requestedLabelIds.filter((id) => {
+        if (existingIds.has(id)) {
+          alreadyPresent.push(id);
+          return false;
+        }
+        return true;
+      });
+    } catch {
+      // Current labels could not be read; attempt every requested label.
+      // A duplicate is still tolerated per-label below.
+    }
+
+    // Add the remaining labels to the task with retry logic
+    const newlyApplied: number[] = [];
+    for (const labelId of toApply) {
       try {
         await withRetry(
           () =>
@@ -51,6 +92,7 @@ export async function applyLabels(args: {
             shouldRetry: (error: unknown) => isAuthenticationError(error),
           },
         );
+        newlyApplied.push(labelId);
       } catch (labelError) {
         // Check if it's an auth error after retries
         if (isAuthenticationError(labelError)) {
@@ -59,18 +101,40 @@ export async function applyLabels(args: {
             `Failed to apply label to task (Retried ${RETRY_CONFIG.AUTH_ERRORS.maxRetries} times)`,
           );
         }
+        // A label already on the task is not a failure: skip it and keep
+        // applying the rest instead of aborting the whole operation.
+        if (isLabelAlreadyOnTaskError(labelError)) {
+          alreadyPresent.push(labelId);
+          continue;
+        }
         throw labelError;
       }
     }
 
     // Fetch the updated task to show current labels
-    const task = await client.tasks.getTask(args.id);
+    const task = await client.tasks.getTask(taskId);
+
+    let message: string;
+    if (newlyApplied.length > 0) {
+      message = `Label${newlyApplied.length > 1 ? 's' : ''} applied to task successfully`;
+      if (alreadyPresent.length > 0) {
+        message += ` (${alreadyPresent.length} already present, skipped)`;
+      }
+    } else {
+      message = `No labels applied: all ${alreadyPresent.length} requested label(s) already present on the task`;
+    }
 
     const response = createSimpleResponse(
       'apply-label',
-      `Label${labelIds.length > 1 ? 's' : ''} applied to task successfully`,
+      message,
       { task },
-      { metadata: { affectedFields: ['labels'] } }
+      {
+        metadata: {
+          affectedFields: ['labels'],
+          labelsApplied: newlyApplied,
+          labelsAlreadyPresent: alreadyPresent,
+        },
+      }
     );
 
     return {
@@ -82,6 +146,9 @@ export async function applyLabels(args: {
       ],
     };
   } catch (error) {
+    if (error instanceof MCPError) {
+      throw error;
+    }
     throw new MCPError(
       ErrorCode.API_ERROR,
       `Failed to apply labels to task: ${error instanceof Error ? error.message : String(error)}`,
@@ -163,6 +230,10 @@ export async function removeLabels(args: {
 
 /**
  * List labels of a task
+ *
+ * Reads the labels from the dedicated GET /tasks/{id}/labels endpoint. The
+ * labels array embedded in a getTask response is not reliably populated, so
+ * relying on it reported zero labels on tasks that actually had some.
  */
 export async function listTaskLabels(args: {
   id?: number;
@@ -178,10 +249,12 @@ export async function listTaskLabels(args: {
 
     const client = await getClientFromContext();
 
-    // Fetch the task to get current labels
-    const task = await client.tasks.getTask(args.id);
+    // Authoritative source for a task's labels
+    const taskLabels = await client.tasks.getTaskLabels(args.id);
+    const labels = Array.isArray(taskLabels) ? taskLabels : [];
 
-    const labels = task.labels || [];
+    // Fetch the task itself only for its identifying fields
+    const task = await client.tasks.getTask(args.id);
 
     const minimalTask: MinimalTask = {
       ...(task.id !== undefined && { id: task.id }),

--- a/src/tools/templates.ts
+++ b/src/tools/templates.ts
@@ -12,6 +12,7 @@ import { getClientFromContext } from '../client';
 import type { Project, Task } from 'node-vikunja';
 import { storageManager } from '../storage';
 import { logger } from '../utils/logger';
+import { setTaskLabels } from '../utils/label-bulk';
 import { formatAorpAsMarkdown } from '../utils/response-factory';
 
 /**
@@ -381,9 +382,7 @@ export function registerTemplatesTool(server: McpServer, authManager: AuthManage
                   // Add labels if any
                   if (taskTemplate.labels && taskTemplate.labels.length > 0) {
                     try {
-                      await client.tasks.updateTaskLabels(createdTask.id ?? 0, {
-                        label_ids: taskTemplate.labels,
-                      });
+                      await setTaskLabels(client, createdTask.id ?? 0, taskTemplate.labels);
                     } catch (labelError) {
                       logger.warn('Failed to add labels to task', {
                         taskId: createdTask.id,

--- a/src/utils/label-bulk.ts
+++ b/src/utils/label-bulk.ts
@@ -1,0 +1,29 @@
+/**
+ * Helper for replacing the full label set of a task.
+ */
+
+import type { VikunjaClient } from 'node-vikunja';
+
+/**
+ * Replace all labels on a task via `POST /tasks/{id}/labels/bulk`.
+ *
+ * node-vikunja types this endpoint's body as `{ label_ids: number[] }`, but
+ * current Vikunja silently ignores that field: it responds `201` and persists
+ * nothing. Vikunja actually requires `{ labels: [{ id }, ...] }`. We send the
+ * shape Vikunja accepts; the cast is required because node-vikunja's
+ * `LabelTaskBulk` type does not describe it.
+ *
+ * The endpoint has replace semantics — the task's labels become exactly
+ * `labelIds` (passing `[]` clears every label).
+ */
+export async function setTaskLabels(
+  client: VikunjaClient,
+  taskId: number,
+  labelIds: number[],
+): Promise<void> {
+  const body = { labels: labelIds.map((id) => ({ id })) };
+  await client.tasks.updateTaskLabels(
+    taskId,
+    body as unknown as Parameters<VikunjaClient['tasks']['updateTaskLabels']>[1],
+  );
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -124,14 +124,18 @@ export async function withRetry<T>(
   options: RetryOptions = {}
 ): Promise<T> {
   const opts = { ...DEFAULT_OPTIONS, ...options };
+  const maxRetries = opts.maxRetries ?? 3;
   let lastError: unknown;
-  let delay = opts.initialDelay || 1000;
+  let delay = opts.initialDelay ?? 1000;
 
-  for (let attempt = 0; attempt <= (opts.maxRetries || 3); attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      // Use circuit breaker for the operation
-      const breaker = createCircuitBreaker(operation, 'anonymous', opts);
-      return await breaker.fire() as Promise<T>;
+      // Execute the operation directly. It must NOT be wrapped in a
+      // name-cached circuit breaker here: opossum binds the action at
+      // construction time, so a breaker reused under a fixed name re-runs
+      // whichever closure reached it first instead of this call's
+      // operation -- silently acting on the wrong task/label/assignee.
+      return await operation();
     } catch (error) {
       lastError = error;
 
@@ -141,16 +145,14 @@ export async function withRetry<T>(
         : isRetryableError(error as Error);
 
       // If this is the last attempt or error is not retryable, throw
-      if (attempt === (opts.maxRetries || 3) || !shouldRetry) {
+      if (attempt === maxRetries || !shouldRetry) {
         throw error;
       }
 
-      // Log retry attempt
-      logger.debug(`Retry attempt ${attempt + 1}/${opts.maxRetries || 3} after ${delay}ms`);
-
-      // Wait before retrying with exponential backoff
+      // Log and wait before retrying with exponential backoff
+      logger.debug(`Retrying operation after ${delay}ms`);
       await new Promise(resolve => setTimeout(resolve, delay));
-      delay = Math.min(delay * (opts.backoffFactor || 2), opts.maxDelay || 30000);
+      delay = Math.min(delay * (opts.backoffFactor ?? 2), opts.maxDelay ?? 30000);
     }
   }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,17 +1,18 @@
 /**
- * Comprehensive Input Sanitization and Security Validation Layer
+ * Input validation and sanitization for the Vikunja MCP server.
  *
- * Provides enterprise-grade protection against:
- * - XSS attacks (script injection, HTML injection)
- * - SQL injection (UNION, boolean-based, time-based)
- * - Command injection (shell command execution)
- * - Path traversal attacks
- * - LDAP injection
- * - NoSQL injection
- * - Unicode and encoding bypasses
- * - Content Security Policy violations
+ * Task titles/descriptions and filter values handled here are only ever sent
+ * to the Vikunja REST API as JSON field values. They are never interpolated
+ * into SQL, a shell command, a filesystem path or an LDAP/NoSQL query, so the
+ * sanitization deliberately does NOT try to detect those injection classes —
+ * blocklisting them previously rejected legitimate content (file paths, URLs,
+ * prose containing words like "select"/"update", "#", "--", "constructor").
  *
- * Integration: Works seamlessly with existing security.ts credential masking
+ * What it still does:
+ * - HTML-entity escaping of values (the Vikunja description field is HTML)
+ * - Rejection of unambiguous <script>/<iframe> HTML injection
+ * - Stripping of zero-width / invisible Unicode used for spoofing
+ * - Prototype-pollution-safe JSON parsing/stringifying for filter expressions
  */
 
 import { z } from 'zod';
@@ -29,9 +30,14 @@ const MAX_NESTING_DEPTH = 10;
 const MAX_CONDITIONS = 50;
 
 /**
- * Maximum string length for filter values (prevents storage bloat)
+ * Maximum string length for sanitized values.
+ *
+ * Vikunja does not cap task description length (the column is a longtext and
+ * the field stores HTML), so this is only a generous backstop against
+ * pathological payloads — not a limit the wrapper should impose on real
+ * content. Descriptions of several thousand characters are routine.
  */
-const MAX_STRING_LENGTH = 1000;
+const MAX_STRING_LENGTH = 1_000_000;
 
 /**
  * Zod schemas for type-safe validation
@@ -73,174 +79,18 @@ export function sanitizeString(value: string): string {
   // Convert to lowercase for case-insensitive pattern matching
   const lowerValue = value.toLowerCase();
 
-  // Create fresh patterns each time to avoid regex state issues
+  // Reject only unambiguous HTML/script injection. Everything else is made
+  // safe by the entity-escaping step below; blocklisting SQL, shell, path or
+  // LDAP/NoSQL "patterns" here only ever rejected legitimate task content
+  // (file paths, URLs, prose with words like "select"/"update", "#", "--").
   const dangerousPatterns = [
-    // Enhanced XSS patterns - comprehensive script and injection detection
-    /<script[^>]*>/gi,
-    /<\/script>/gi,
-    /<iframe[^>]*>/gi,
-    /<\/iframe>/gi,
-    /<object[^>]*>/gi,
-    /<\/object>/gi,
-    /<embed[^>]*>/gi,
-    /<link[^>]*>/gi,
-    /<meta[^>]*>/gi,
-    /<svg[^>]*>/gi,
-    /<\/svg>/gi,
-    /<style[^>]*>/gi,
-    /<\/style>/gi,
-    /<img[^>]*on[^>]*>/gi,
-    /<div[^>]*on[^>]*>/gi,
-    /<a[^>]*on[^>]*>/gi,
-    /<body[^>]*on[^>]*>/gi,
-    /<form[^>]*on[^>]*>/gi,
-    /<input[^>]*on[^>]*>/gi,
-    /<button[^>]*on[^>]*>/gi,
-    /<select[^>]*on[^>]*>/gi,
-    /<textarea[^>]*on[^>]*>/gi,
-
-    // Event handlers with attributes (more specific to avoid false positives)
-    /on\w+\s*=\s*["'][^"']*["']/gi,
-    /onclick/gi,
-    /onload/gi,
-    /onerror/gi,
-    /onmouseover/gi,
-    /onmouseout/gi,
-    /onmousedown/gi,
-    /onmouseup/gi,
-    /onkeydown/gi,
-    /onkeyup/gi,
-    /onkeypress/gi,
-    /onfocus/gi,
-    /onblur/gi,
-    /onchange/gi,
-    /onsubmit/gi,
-    /onreset/gi,
-    /onselect/gi,
-    /onunload/gi,
-    /onabort/gi,
-    /oncanplay/gi,
-    /oncanplaythrough/gi,
-    /oncuechange/gi,
-    /ondurationchange/gi,
-    /onemptied/gi,
-    /onended/gi,
-    /onerror/gi,
-    /onloadeddata/gi,
-    /onloadedmetadata/gi,
-    /onloadstart/gi,
-    /onpause/gi,
-    /onplay/gi,
-    /onplaying/gi,
-    /onprogress/gi,
-    /onratechange/gi,
-    /onseeked/gi,
-    /onseeking/gi,
-    /onstalled/gi,
-    /onsuspend/gi,
-    /ontimeupdate/gi,
-    /onvolumechange/gi,
-    /onwaiting/gi,
-
-    // Dangerous protocols and schemes
-    /javascript:/gi,
-    /vbscript:/gi,
-    /data:text\/html/gi,
-    /data:application\/javascript/gi,
-    /data:text\/javascript/gi,
-    /data:text\/vbscript/gi,
-    /data:application\/x-javascript/gi,
-
-    // CSS-based attacks
-    /expression\s*\(/gi,
-    /@import/gi,
-    /url\s*\(/gi,
-    /binding\s*:/gi,
-    /behavior\s*:/gi,
-    /-moz-binding\s*:/gi,
-    /-o-link\s*:/gi,
-    /-webkit-binding\s*:/gi,
-
-    // SQL injection patterns
-    /(\b(SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|EXEC|UNION|EXECUTE|TRUNCATE)\b)/gi,
-    /(\b(OR|AND)\s+\d+\s*=\s*\d+)/gi,
-    /(\b(OR|AND)\s+['"].*['"]\s*=\s*['"].*['"])/gi,
-    /(\b(WAITFOR\s+DELAY|SLEEP\s*\(|BENCHMARK\s*\(|DBMS_PIPE\.RECEIVE_MESSAGE)\b)/gi,
-    /(--|#|\/\*|\*\/)/gi,  // SQL comments
-    /(\b(INFORMATION_SCHEMA|SYS|MASTER|MSDB|MYSQL|PG_CATALOG)\b)/gi,
-    /(\b(XP_|SP_)\w+)/gi,  // SQL Server extended procedures
-
-    // Command injection patterns (more specific to avoid false positives)
-    // Removed the broad shell pattern to allow safe HTML tags that should be escaped instead of rejected
-    /(\b(wget|curl|nc|netcat|telnet|ssh|ftp|sftp)\b)/gi,
-    /(rm\s+-rf|del\s+\/s|format|fdisk|mkfs)/gi,
-    /(>\s*\/dev\/null|2>&1|\|\|)/gi,
-    /(\$\([^)]*\)|`[^`]*`)/gi,  // Command substitution
-
-    // Path traversal patterns
-    /(\.\.[/\\])/gi,
-    /(%2e%2e[/\\])/gi,
-    /(%2e%2e%2f)/gi,  // URL-encoded ../
-    /(%2e%2e%5c)/gi,  // URL-encoded ..\
-    /(\/etc\/passwd|\/etc\/shadow|\/proc\/)/gi,
-    /(c:\\\\windows\\\\system32|\\\\..\\\\)/gi,
-
-    // LDAP injection patterns
-    /(\*\)\([&*)]*)/gi,
-    /(\*\)([^)]*\*)*)/gi,
-    /(\|\()([^)]*)(\)\|)/gi,
-    /(!\()([^)]*)(\))/gi,
-
-    // NoSQL injection patterns
-    /(\$\w+\s*:)/gi,  // MongoDB operators like $gt, $lt, $where
-    /(\{\s*\$where\s*:)/gi,
-    /(\{\s*\$ne\s*:)/gi,
-    /(\{\s*\$gt\s*:)/gi,
-    /(\{\s*\$regex\s*:)/gi,
-
-    // HTML5 dangerous attributes
-    /formaction\s*=/gi,
-    /poster\s*=/gi,
-    /autofocus\s*=/gi,
-    /controls\s*=/gi,
-    /autoplay\s*=/gi,
-    /loop\s*=/gi,
-    /muted\s*=/gi,
-
-    // Unicode and encoding bypass attempts
-    /[\u200b-\u200f\u2060\u180e\ufeff]/g,  // Zero-width and invisible characters
-    /[\uFE00-\uFE0F]/g,  // Variation selectors
-    /\\u[0-9a-fA-F]{4}/g,  // Unicode escapes
-    /\\x[0-9a-fA-F]{2}/g,  // Hex escapes
-
-    // Prototype pollution patterns
-    /(__proto__|constructor|prototype)/gi,
-
-    // Content Security Policy violations
-    /(base64|atob|btoa|eval|Function|setTimeout|setInterval)\s*\(/gi,
-    /(document\.(write|writeln|open|close)|window\.(open|location|navigate))/gi,
-
-    // HTML-encoded dangerous content (prevent XSS through encoded vectors)
-    /&lt;script[^&]*&gt;/gi,
-    /&lt;\/script&gt;/gi,
-    /&lt;iframe[^&]*&gt;/gi,
-    /&lt;\/iframe&gt;/gi,
-    /&lt;object[^&]*&gt;/gi,
-    /&lt;svg[^&]*&gt;/gi,
-    /&lt;img[^&]*on[^&]*&gt;/gi,
-    /&lt;div[^&]*on[^&]*&gt;/gi,
-    /&lt;a[^&]*on[^&]*&gt;/gi,
-    /&lt;body[^&]*on[^&]*&gt;/gi,
-    /&lt;style[^&]*&gt;/gi,
-    /&lt;form[^&]*on[^&]*&gt;/gi,
-    /javascript:[^&]*/gi,
-    /on\w+[^&]*=/gi,
-    /&lt;!--.*?--&gt;/gis,  // HTML-encoded comments
+    /<script[\s/>]/i,
+    /<\/script\s*>/i,
+    /<iframe[\s/>]/i,
+    /<\/iframe\s*>/i,
   ];
 
   for (const pattern of dangerousPatterns) {
-    // Reset regex lastIndex to avoid state issues with global flags
-    pattern.lastIndex = 0;
     if (pattern.test(lowerValue)) {
       throw new MCPError(ErrorCode.VALIDATION_ERROR, 'String contains potentially dangerous content');
     }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -8,9 +8,14 @@
  * blocklisting them previously rejected legitimate content (file paths, URLs,
  * prose containing words like "select"/"update", "#", "--", "constructor").
  *
+ * It does NOT HTML-escape values: these strings are JSON fields for the
+ * Vikunja API, not HTML this wrapper renders. Vikunja shows the task title
+ * as plain text (escaping displayed a literal "&#x2F;") and sanitizes the
+ * description's HTML itself, so escaping here only corrupted content.
+ *
  * What it still does:
- * - HTML-entity escaping of values (the Vikunja description field is HTML)
  * - Rejection of unambiguous <script>/<iframe> HTML injection
+ * - Unicode NFC normalization
  * - Stripping of zero-width / invisible Unicode used for spoofing
  * - Prototype-pollution-safe JSON parsing/stringifying for filter expressions
  */
@@ -63,8 +68,11 @@ const LogicalOperatorSchema: z.ZodType<LogicalOperator> = z.enum(['&&', '||']);
  */
 
 /**
- * Validate and sanitize a string value to prevent XSS using pattern matching + HTML escaping
- * Server-appropriate approach that avoids DOM parsing while providing comprehensive protection
+ * Validate a string value for use as a Vikunja API field.
+ *
+ * Rejects unambiguous <script>/<iframe> injection, then NFC-normalizes and
+ * strips invisible spoofing characters. It does NOT HTML-escape the value:
+ * see the module header for why escaping here corrupted titles and paths.
  */
 export function sanitizeString(value: string): string {
   if (typeof value !== 'string') {
@@ -75,14 +83,11 @@ export function sanitizeString(value: string): string {
     throw new MCPError(ErrorCode.VALIDATION_ERROR, `String value exceeds maximum length of ${MAX_STRING_LENGTH}`);
   }
 
-  // Step 1: Check for dangerous HTML/JavaScript patterns and REJECT them (don't sanitize)
-  // Convert to lowercase for case-insensitive pattern matching
+  // Step 1: Reject only unambiguous HTML/script injection. Blocklisting SQL,
+  // shell, path or LDAP/NoSQL "patterns" here only ever rejected legitimate
+  // task content (file paths, URLs, prose with words like "select"/"update").
   const lowerValue = value.toLowerCase();
 
-  // Reject only unambiguous HTML/script injection. Everything else is made
-  // safe by the entity-escaping step below; blocklisting SQL, shell, path or
-  // LDAP/NoSQL "patterns" here only ever rejected legitimate task content
-  // (file paths, URLs, prose with words like "select"/"update", "#", "--").
   const dangerousPatterns = [
     /<script[\s/>]/i,
     /<\/script\s*>/i,
@@ -96,32 +101,16 @@ export function sanitizeString(value: string): string {
     }
   }
 
-  // Step 2: Apply comprehensive sanitization for safe content
-
-  // First, normalize Unicode to prevent bypass attacks
+  // Step 2: Normalize Unicode. No HTML-entity escaping and no path-traversal
+  // rewriting: these values are JSON fields for the Vikunja API, not HTML or
+  // filesystem paths, and doing either here corrupted legitimate content.
   let normalizedValue = value.normalize('NFC');
 
-  // Remove dangerous Unicode characters that weren't caught by pattern matching
+  // Strip zero-width / invisible characters used for spoofing.
   normalizedValue = normalizedValue.replace(/[\u200b-\u200f\u2060\u180e\ufeff]/g, '');
   normalizedValue = normalizedValue.replace(/[\uFE00-\uFE0F]/g, '');
 
-  // Apply path traversal sanitization for file system safety
-  normalizedValue = normalizedValue.replace(/\.\.[/\\]/g, '...');
-  normalizedValue = normalizedValue.replace(/%2e%2e[/\\]/gi, '...');
-  normalizedValue = normalizedValue.replace(/\/etc\/passwd/gi, 'etc/passwd');
-  normalizedValue = normalizedValue.replace(/c:\\windows\\system32/gi, 'c:/windows/system32');
-
-  // Apply proper HTML escaping (order matters: & must be first)
-  return normalizedValue
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
-    .replace(/\//g, '&#x2F;')
-    .replace(/\\/g, '&#x5C;')  // Escape backslashes too
-    .replace(/`/g, '&#x60;')   // Escape backticks
-    .replace(/=/g, '&#x3D;')   // Escape equals signs in attributes
+  return normalizedValue;
 }
 
 /**

--- a/src/utils/vikunja-rest.ts
+++ b/src/utils/vikunja-rest.ts
@@ -1,0 +1,125 @@
+/**
+ * Direct REST helper for Vikunja API endpoints not covered by node-vikunja.
+ *
+ * node-vikunja (the typed client this MCP server wraps) does not expose the
+ * Kanban view endpoints — listing the buckets of a view, or placing a task
+ * into a bucket. Those operations therefore call the Vikunja REST API
+ * directly, reusing the credentials of the active authenticated session.
+ */
+
+import type { AuthManager } from '../auth/AuthManager';
+import { MCPError, ErrorCode } from '../types';
+
+/**
+ * Performs an authenticated request against the Vikunja REST API.
+ *
+ * @param authManager - Active auth manager holding the session credentials
+ * @param method - HTTP method
+ * @param path - API path relative to the configured apiUrl, must start with '/'
+ *               (e.g. '/projects/4/views')
+ * @param body - Optional value serialized as a JSON request body
+ * @returns The parsed JSON response, or null when the response has no body
+ * @throws MCPError when the network call fails or the response is not OK
+ */
+export async function vikunjaRestRequest<T = unknown>(
+  authManager: AuthManager,
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const session = authManager.getSession();
+  // session.apiUrl may or may not already include the `/api/v1` prefix
+  // depending on how VIKUNJA_URL was configured; normalize so REST paths
+  // (which are relative to the API root) always resolve correctly.
+  const trimmed = session.apiUrl.replace(/\/+$/, '');
+  const baseUrl = /\/api\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/api/v1`;
+  const url = `${baseUrl}${path}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${session.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+  } catch (error) {
+    throw new MCPError(
+      ErrorCode.API_ERROR,
+      `Vikunja REST request failed (${method} ${path}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (!response.ok) {
+    let detail = '';
+    try {
+      detail = (await response.text()).slice(0, 500);
+    } catch {
+      // Body could not be read — fall back to the status line only.
+    }
+    throw new MCPError(
+      ErrorCode.API_ERROR,
+      `Vikunja REST request failed (${method} ${path}): HTTP ${response.status} ${
+        response.statusText
+      }${detail ? ` — ${detail}` : ''}`,
+    );
+  }
+
+  const text = await response.text();
+  if (!text) {
+    return null as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    // A 2xx response with a non-JSON body (rare) is treated as an empty result.
+    return null as T;
+  }
+}
+
+/**
+ * Minimal shape of a Vikunja project view as returned by `/projects/{id}/views`.
+ */
+export interface VikunjaView {
+  id: number;
+  title: string;
+  project_id: number;
+  view_kind: string;
+}
+
+/**
+ * Resolves the Kanban view id for a project.
+ *
+ * Vikunja projects have several views (list, gantt, table, kanban). Bucket
+ * operations only make sense against the Kanban view, so callers that do not
+ * already know the view id can use this to find it.
+ *
+ * @param authManager - Active auth manager
+ * @param projectId - Project whose Kanban view should be resolved
+ * @returns The numeric id of the project's Kanban view
+ * @throws MCPError when the project has no Kanban view
+ */
+export async function resolveKanbanViewId(
+  authManager: AuthManager,
+  projectId: number,
+): Promise<number> {
+  const views = await vikunjaRestRequest<VikunjaView[]>(
+    authManager,
+    'GET',
+    `/projects/${projectId}/views`,
+  );
+  const kanban = Array.isArray(views)
+    ? views.find((view) => view.view_kind === 'kanban')
+    : undefined;
+  if (!kanban) {
+    throw new MCPError(
+      ErrorCode.NOT_FOUND,
+      `Project ${projectId} has no Kanban view, so it has no buckets`,
+    );
+  }
+  return kanban.id;
+}

--- a/tests/services/TaskCreationService.test.ts
+++ b/tests/services/TaskCreationService.test.ts
@@ -251,7 +251,7 @@ describe('TaskCreationService', () => {
       expect(result.success).toBe(true);
       expect(result.warnings).toBeUndefined();
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(123, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
       expect(mockClient.tasks.getTask).toHaveBeenCalledWith(123);
     });

--- a/tests/tools/batch-import.test.ts
+++ b/tests/tools/batch-import.test.ts
@@ -257,7 +257,7 @@ describe('Batch Import Tool', () => {
       });
 
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(103, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
       expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalledWith(103, {
         user_ids: [10, 11],
@@ -353,7 +353,7 @@ Task 2,Description 2,2,true`;
       });
 
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(203, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
     });
 
@@ -733,7 +733,7 @@ Description,1`;
 
       // Verify updateTaskLabels was called with correct label IDs
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(122, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
 
       // Verify getTask was called to check if labels were actually assigned
@@ -1116,7 +1116,7 @@ Description,1`;
 
       // Should map correctly despite case differences
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1101, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
     });
 
@@ -1368,7 +1368,7 @@ Description,1`;
 
       // Should update with only the found label
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1801, {
-        label_ids: [1],
+        labels: [{ id: 1 }],
       });
       
       // Task completed successfully, only 'bug' label was applied

--- a/tests/tools/projects/buckets.test.ts
+++ b/tests/tools/projects/buckets.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the project Kanban bucket listing operation (`list-buckets`).
+ *
+ * Covers id validation, view auto-resolution vs an explicit viewId, empty and
+ * non-array bucket responses, optional bucket fields, and error propagation.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../../src/auth/AuthManager';
+import { listBuckets } from '../../../src/tools/projects/buckets';
+import { MCPError, ErrorCode } from '../../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** Minimal Response-like object for the REST helper. */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+}): Response {
+  const { ok = true, status = 200, statusText = 'OK', text = '' } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+/** A views payload containing a Kanban view (id 11). */
+const kanbanViews = JSON.stringify([
+  { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+  { id: 11, title: 'Kanban', project_id: 5, view_kind: 'kanban' },
+]);
+
+describe('listBuckets', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('validation', () => {
+    it('throws a VALIDATION_ERROR when the project id is missing', async () => {
+      await expect(listBuckets({}, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'Project id is required for list-buckets operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when the project id is zero (falsy)', async () => {
+      await expect(listBuckets({ id: 0 }, authManager)).rejects.toThrow(
+        'Project id is required for list-buckets operation',
+      );
+    });
+
+    it('throws when the project id is not a positive integer', async () => {
+      await expect(listBuckets({ id: -3 }, authManager)).rejects.toThrow(
+        'id must be a positive integer',
+      );
+    });
+
+    it('throws when an explicit viewId is invalid', async () => {
+      await expect(listBuckets({ id: 5, viewId: 0 }, authManager)).rejects.toThrow(
+        'viewId must be a positive integer',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('view resolution', () => {
+    it('resolves the Kanban view id when viewId is omitted', async () => {
+      // 1) GET /projects/:id/views  2) GET buckets
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(
+          mockResponse({
+            text: JSON.stringify([
+              {
+                id: 100,
+                title: 'Backlog',
+                project_view_id: 11,
+                position: 0,
+                limit: 0,
+                is_done_bucket: false,
+              },
+              {
+                id: 101,
+                title: 'Done',
+                project_view_id: 11,
+                position: 1,
+                limit: 5,
+                is_done_bucket: true,
+              },
+            ]),
+          }),
+        );
+
+      const result = await listBuckets({ id: 5 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[1]).toBe('https://vikunja.test/api/v1/projects/5/views/11/buckets');
+
+      const text = result.content[0].text;
+      expect(text).toContain('Found 2 buckets in the Kanban view of project 5');
+      expect(text).toContain('Backlog');
+      expect(text).toContain('Done');
+    });
+
+    it('uses an explicit viewId without resolving the Kanban view', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([{ id: 100, title: 'Backlog' }]),
+        }),
+      );
+
+      const result = await listBuckets({ id: 5, viewId: 42 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/5/views/42/buckets');
+      expect(result.content[0].text).toContain('Found 1 buckets');
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([
+            { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+          ]),
+        }),
+      );
+
+      await expect(listBuckets({ id: 5 }, authManager)).rejects.toThrow(
+        'Project 5 has no Kanban view, so it has no buckets',
+      );
+    });
+  });
+
+  describe('bucket response handling', () => {
+    it('returns an empty bucket list when the API returns an empty array', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      expect(result.content[0].text).toContain('Found 0 buckets');
+    });
+
+    it('treats a non-array bucket response as an empty list', async () => {
+      // An empty 2xx body resolves to null inside vikunjaRestRequest.
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      expect(result.content[0].text).toContain('Found 0 buckets');
+    });
+
+    it('defaults isDoneBucket to false when the field is absent', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          text: JSON.stringify([{ id: 100, title: 'Backlog' }]),
+        }),
+      );
+
+      const result = await listBuckets({ id: 5, viewId: 11 }, authManager);
+
+      const text = result.content[0].text;
+      expect(text).toContain('Found 1 buckets');
+      expect(text).toContain('"isDoneBucket": false');
+    });
+
+    it('passes a session id through to the response', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      const result = await listBuckets(
+        { id: 5, viewId: 11, sessionId: 'sess-9' },
+        authManager,
+      );
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Success');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates an HTTP error from the buckets request', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: 'view does not exist',
+        }),
+      );
+
+      await expect(
+        listBuckets({ id: 5, viewId: 11 }, authManager),
+      ).rejects.toThrow(MCPError);
+    });
+
+    it('propagates a network error raised while resolving the view', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('offline'));
+
+      await expect(listBuckets({ id: 5 }, authManager)).rejects.toThrow(
+        'Vikunja REST request failed (GET /projects/5/views): offline',
+      );
+    });
+  });
+});

--- a/tests/tools/tasks.test.ts
+++ b/tests/tools/tasks.test.ts
@@ -853,7 +853,7 @@ describe('Tasks Tool', () => {
 
       // Labels are updated via updateTaskLabels
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
     });
 
@@ -2569,7 +2569,7 @@ describe('Tasks Tool', () => {
       const result = await callTool('bulk-create', { projectId: 1, tasks });
 
       expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
-        label_ids: [1, 2],
+        labels: [{ id: 1 }, { id: 2 }],
       });
       expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalledWith(1, {
         user_ids: [3, 4],

--- a/tests/tools/tasks/buckets.test.ts
+++ b/tests/tools/tasks/buckets.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the task Kanban bucket operation (`set-bucket`).
+ *
+ * Covers validation of required/optional ids, project and view auto-resolution,
+ * explicit project/view ids, and propagation of REST errors.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../../src/auth/AuthManager';
+import { setTaskBucket } from '../../../src/tools/tasks/buckets';
+import { MCPError, ErrorCode } from '../../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** Minimal Response-like object for the REST helper. */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+}): Response {
+  const { ok = true, status = 200, statusText = 'OK', text = '' } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+/** A views payload containing a Kanban view (id 11). */
+const kanbanViews = JSON.stringify([
+  { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+  { id: 11, title: 'Kanban', project_id: 5, view_kind: 'kanban' },
+]);
+
+describe('setTaskBucket', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('validation', () => {
+    it('throws a VALIDATION_ERROR when the task id is missing', async () => {
+      await expect(setTaskBucket({ bucketId: 3 }, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'Task id is required for set-bucket operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when the task id is zero (falsy)', async () => {
+      await expect(
+        setTaskBucket({ id: 0, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Task id is required for set-bucket operation');
+    });
+
+    it('throws a VALIDATION_ERROR when bucketId is undefined', async () => {
+      await expect(setTaskBucket({ id: 1 }, authManager)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'bucketId is required for set-bucket operation',
+        ),
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws a VALIDATION_ERROR when bucketId is null', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: null as unknown as number }, authManager),
+      ).rejects.toThrow('bucketId is required for set-bucket operation');
+    });
+
+    it('treats a bucketId of 0 as provided and validates it as an id', async () => {
+      // bucketId 0 passes the undefined/null guard but fails validateId.
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 0 }, authManager),
+      ).rejects.toThrow('bucketId must be a positive integer');
+    });
+
+    it('throws when the task id is not a positive integer', async () => {
+      await expect(
+        setTaskBucket({ id: -2, bucketId: 3 }, authManager),
+      ).rejects.toThrow('id must be a positive integer');
+    });
+
+    it('throws when an explicit viewId is invalid', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, viewId: -1 }, authManager),
+      ).rejects.toThrow('viewId must be a positive integer');
+    });
+
+    it('throws when an explicit projectId is invalid', async () => {
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, projectId: 0 }, authManager),
+      ).rejects.toThrow('projectId must be a positive integer');
+    });
+  });
+
+  describe('project and view resolution', () => {
+    it('resolves project and view ids from the API when both are omitted', async () => {
+      // 1) GET /tasks/:id  2) GET /projects/:id/views  3) POST bucket task
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 5, title: 'T' }) }),
+        )
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await setTaskBucket({ id: 1, bucketId: 3 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/tasks/1');
+      expect(urls[1]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[2]).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+
+      // The POST body carries the TaskBucket payload.
+      const [, postInit] = mockFetch.mock.calls[2] as [string, RequestInit];
+      expect(postInit.method).toBe('POST');
+      expect(postInit.body).toBe(JSON.stringify({ task_id: 1, bucket_id: 3 }));
+
+      const text = result.content[0].text;
+      expect(text).toContain('Task 1 moved to bucket 3');
+      expect(text).toContain('Success');
+    });
+
+    it('does not fetch the task when projectId is supplied explicitly', async () => {
+      // 1) GET /projects/:id/views  2) POST bucket task
+      mockFetch
+        .mockResolvedValueOnce(mockResponse({ text: kanbanViews }))
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await setTaskBucket({ id: 1, bucketId: 3, projectId: 5 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/projects/5/views');
+      expect(urls[1]).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+    });
+
+    it('does not resolve the view when viewId is supplied explicitly', async () => {
+      // projectId omitted -> GET /tasks/:id, then POST (no views lookup)
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 8 }) }),
+        )
+        .mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await setTaskBucket({ id: 1, bucketId: 3, viewId: 22 }, authManager);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const urls = mockFetch.mock.calls.map((c) => c[0]);
+      expect(urls[0]).toBe('https://vikunja.test/api/v1/tasks/1');
+      expect(urls[1]).toBe(
+        'https://vikunja.test/api/v1/projects/8/views/22/buckets/3/tasks',
+      );
+    });
+
+    it('issues only the bucket POST when both projectId and viewId are supplied', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await setTaskBucket(
+        { id: 1, bucketId: 3, projectId: 5, viewId: 11, sessionId: 'sess-1' },
+        authManager,
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe(
+        'https://vikunja.test/api/v1/projects/5/views/11/buckets/3/tasks',
+      );
+      expect(result.content[0].type).toBe('text');
+    });
+
+    it('throws NOT_FOUND when the task lookup returns no body', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow(
+        new MCPError(
+          ErrorCode.NOT_FOUND,
+          'Could not resolve the project of task 1',
+        ),
+      );
+    });
+
+    it('throws NOT_FOUND when the task has no numeric project_id', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ text: JSON.stringify({ id: 1, project_id: 'oops' }) }),
+      );
+
+      try {
+        await setTaskBucket({ id: 1, bucketId: 3 }, authManager);
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.NOT_FOUND);
+      }
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          mockResponse({ text: JSON.stringify({ id: 1, project_id: 5 }) }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            text: JSON.stringify([
+              { id: 10, title: 'List', project_id: 5, view_kind: 'list' },
+            ]),
+          }),
+        );
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Project 5 has no Kanban view, so it has no buckets');
+    });
+  });
+
+  describe('error propagation', () => {
+    it('propagates an HTTP error from the bucket POST', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: 'invalid bucket',
+        }),
+      );
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3, projectId: 5, viewId: 11 }, authManager),
+      ).rejects.toThrow(MCPError);
+    });
+
+    it('propagates a network error raised while resolving the task', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+      await expect(
+        setTaskBucket({ id: 1, bucketId: 3 }, authManager),
+      ).rejects.toThrow('Vikunja REST request failed (GET /tasks/1): network down');
+    });
+  });
+});

--- a/tests/tools/tasks/bulk-operations.test.ts
+++ b/tests/tools/tasks/bulk-operations.test.ts
@@ -299,6 +299,42 @@ describe('Bulk operations', () => {
       });
     });
 
+    describe('Labels field', () => {
+      it('should set labels via the field-preserving fallback path', async () => {
+        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTaskLabels.mockResolvedValue({});
+
+        const result = await bulkUpdateTasks({ taskIds: [1], field: 'labels', value: [3, 8] });
+
+        // labels must never go through the native /tasks/bulk endpoint
+        expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+        expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
+          labels: [{ id: 3 }, { id: 8 }],
+        });
+        expect(result.content[0].text).toContain('## ✅ Success');
+      });
+
+      it('should coerce a stringified labels array', async () => {
+        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'Task 1' });
+        mockClient.tasks.updateTaskLabels.mockResolvedValue({});
+
+        const result = await bulkUpdateTasks({ taskIds: [1], field: 'labels', value: '[3, 8]' });
+
+        expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
+          labels: [{ id: 3 }, { id: 8 }],
+        });
+        expect(result.content[0].text).toContain('## ✅ Success');
+      });
+
+      it('should reject a labels value that is not a list of numbers', async () => {
+        await expect(
+          bulkUpdateTasks({ taskIds: [1], field: 'labels', value: 'not-a-list' }),
+        ).rejects.toThrow('labels must be an array of numbers');
+      });
+    });
+
     describe('Error handling', () => {
       it('should preserve MCPError instances', async () => {
         const mcpError = new MCPError(ErrorCode.NOT_FOUND, 'Task not found');
@@ -524,7 +560,7 @@ describe('Bulk operations', () => {
         });
 
         expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(1, {
-          label_ids: [1],
+          labels: [{ id: 1 }],
         });
         expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalledWith(1, {
           user_ids: [1],

--- a/tests/tools/tasks/labels.test.ts
+++ b/tests/tools/tasks/labels.test.ts
@@ -18,6 +18,7 @@ describe('Label operations', () => {
       addLabelToTask: jest.fn(),
       removeLabelFromTask: jest.fn(),
       getTask: jest.fn(),
+      getTaskLabels: jest.fn(),
     },
   };
 
@@ -25,6 +26,8 @@ describe('Label operations', () => {
     // Use resetAllMocks to also reset mock implementations (not just call history)
     jest.resetAllMocks();
     mockGetClientFromContext.mockResolvedValue(mockClient as any);
+    // Default: task has no labels yet
+    mockClient.tasks.getTaskLabels.mockResolvedValue([]);
   });
 
   describe('applyLabels', () => {
@@ -65,6 +68,52 @@ describe('Label operations', () => {
 
       expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledTimes(2);
       expect(result.content[0].text).toContain('Labels applied to task successfully');
+    });
+
+    it('should skip labels already present on the task', async () => {
+      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      // Label 1 is already on the task; only label 2 should be applied.
+      mockClient.tasks.getTaskLabels.mockResolvedValue([{ id: 1, title: 'research' }]);
+      mockClient.tasks.addLabelToTask.mockResolvedValue({});
+      mockClient.tasks.getTask.mockResolvedValue(mockTask);
+
+      const result = await applyLabels({ id: 1, labels: [1, 2] });
+
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledTimes(1);
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledWith(1, {
+        task_id: 1,
+        label_id: 2,
+      });
+      expect(result.content[0].text).toContain('already present');
+    });
+
+    it('should not abort when a label is already on the task', async () => {
+      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      // getTaskLabels reports nothing, but addLabelToTask races and rejects
+      // the first label as a duplicate; the rest must still be applied.
+      mockClient.tasks.addLabelToTask
+        .mockRejectedValueOnce(new Error('This label already exists on the task'))
+        .mockResolvedValueOnce({});
+      mockClient.tasks.getTask.mockResolvedValue(mockTask);
+
+      const result = await applyLabels({ id: 1, labels: [1, 2] });
+
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledTimes(2);
+      expect(result.content[0].text).toContain('Label applied to task successfully');
+    });
+
+    it('should report when every requested label is already present', async () => {
+      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      mockClient.tasks.getTaskLabels.mockResolvedValue([
+        { id: 1, title: 'research' },
+        { id: 2, title: 'ops' },
+      ]);
+      mockClient.tasks.getTask.mockResolvedValue(mockTask);
+
+      const result = await applyLabels({ id: 1, labels: [1, 2] });
+
+      expect(mockClient.tasks.addLabelToTask).not.toHaveBeenCalled();
+      expect(result.content[0].text).toContain('No labels applied');
     });
 
     it('should handle API errors gracefully', async () => {
@@ -108,16 +157,15 @@ describe('Label operations', () => {
 
   describe('listTaskLabels', () => {
     it('should list labels for a task successfully', async () => {
-      const mockTask = {
-        id: 1,
-        title: 'Test Task',
-        labels: [{ id: 1, title: 'research', hex_color: '3498db' }],
-      };
+      const mockTask = { id: 1, title: 'Test Task' };
+      mockClient.tasks.getTaskLabels.mockResolvedValue([
+        { id: 1, title: 'research', hex_color: '3498db' },
+      ]);
       mockClient.tasks.getTask.mockResolvedValue(mockTask);
 
       const result = await listTaskLabels({ id: 1 });
 
-      expect(mockClient.tasks.getTask).toHaveBeenCalledWith(1);
+      expect(mockClient.tasks.getTaskLabels).toHaveBeenCalledWith(1);
       expect(result.content[0].text).toContain('Task has 1 label(s)');
     });
 
@@ -126,7 +174,8 @@ describe('Label operations', () => {
     });
 
     it('should handle task with no labels', async () => {
-      const mockTask = { id: 1, title: 'Test Task', labels: [] };
+      const mockTask = { id: 1, title: 'Test Task' };
+      mockClient.tasks.getTaskLabels.mockResolvedValue([]);
       mockClient.tasks.getTask.mockResolvedValue(mockTask);
 
       const result = await listTaskLabels({ id: 1 });

--- a/tests/tools/templates.test.ts
+++ b/tests/tools/templates.test.ts
@@ -1172,7 +1172,7 @@ describe('Templates Tool', () => {
       });
 
       // Should use 0 as fallback for null task ID
-      expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(0, { label_ids: [1, 2] });
+      expect(mockClient.tasks.updateTaskLabels).toHaveBeenCalledWith(0, { labels: [{ id: 1 }, { id: 2 }] });
     });
 
     it('should handle variable names with regex special characters', async () => {

--- a/tests/utils/input-sanitization.test.ts
+++ b/tests/utils/input-sanitization.test.ts
@@ -1,413 +1,168 @@
 /**
- * Input Sanitization Security Tests
- * Tests for comprehensive input sanitization layer to prevent injection attacks
+ * Input sanitization tests for sanitizeString and the helpers built on it.
  *
- * These tests initially FAIL to demonstrate vulnerabilities, then pass after sanitization implementation
+ * sanitizeString only ever feeds task titles/descriptions and filter values
+ * into the Vikunja REST API as JSON field values — there is no SQL, shell,
+ * filesystem or LDAP/NoSQL sink behind it. It therefore:
+ *   - rejects values past MAX_STRING_LENGTH (a generous DoS backstop)
+ *   - rejects unambiguous <script>/<iframe> HTML injection
+ *   - HTML-escapes everything else (the Vikunja description field is HTML)
+ *
+ * These tests double as regression coverage for the previously over-broad
+ * blocklist, which wrongly rejected file paths, external URLs and ordinary
+ * prose. See git history / fix: relax sanitizeString.
  */
 
 import {
   sanitizeString,
   validateValue,
-  safeJsonStringify,
-  safeJsonParse
+  safeJsonParse,
 } from '../../src/utils/validation';
 import { sanitizeLogData } from '../../src/utils/security';
 
-describe('Input Sanitization Security Tests', () => {
-  describe('XSS Protection in Task Content', () => {
-    it('should block script tags in task titles', () => {
-      const maliciousTitle = '<script>alert("XSS")</script>Task Title';
-
-      expect(() => {
-        sanitizeString(maliciousTitle);
-      }).toThrow('contains potentially dangerous content');
+describe('sanitizeString', () => {
+  describe('rejects unambiguous script/iframe injection', () => {
+    it('rejects <script> tags', () => {
+      expect(() => sanitizeString('<script>alert(1)</script>')).toThrow(
+        'contains potentially dangerous content',
+      );
     });
 
-    it('should block onclick handlers in task descriptions', () => {
-      const maliciousDescription = 'Click here <div onclick="alert(\'XSS\')">malicious</div>';
-
-      expect(() => {
-        sanitizeString(maliciousDescription);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block javascript: URLs', () => {
-      const maliciousUrl = 'javascript:alert("XSS")';
-
-      expect(() => {
-        sanitizeString(maliciousUrl);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block data: URLs with HTML', () => {
-      const maliciousDataUrl = 'data:text/html,<script>alert("XSS")</script>';
-
-      expect(() => {
-        sanitizeString(maliciousDataUrl);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block HTML-encoded XSS attempts', () => {
-      const encodedXss = '&lt;script&gt;alert("XSS")&lt;/script&gt;';
-
-      expect(() => {
-        sanitizeString(encodedXss);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block CSS-based XSS', () => {
-      const cssXss = '<style>body { background: url("javascript:alert(\'XSS\')") }</style>';
-
-      expect(() => {
-        sanitizeString(cssXss);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block SVG-based XSS', () => {
-      const svgXss = '<svg onload="alert(\'XSS\')"></svg>';
-
-      expect(() => {
-        sanitizeString(svgXss);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block iframe injection', () => {
-      const iframeInjection = '<iframe src="javascript:alert(\'XSS\')"></iframe>';
-
-      expect(() => {
-        sanitizeString(iframeInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block expression() CSS injection', () => {
-      const expressionInjection = '<div style="background: expression(alert(\'XSS\'))">';
-
-      expect(() => {
-        sanitizeString(expressionInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block @import CSS injection', () => {
-      const importInjection = '<style>@import url("javascript:alert(\'XSS\')");</style>';
-
-      expect(() => {
-        sanitizeString(importInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('SQL Injection Protection in Filter Values', () => {
-    it('should block SQL injection attempts in filter values', () => {
-      const sqlInjection = "'; DROP TABLE tasks; --";
-
-      // This should be rejected for dangerous SQL patterns
-      expect(() => {
-        sanitizeString(sqlInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block UNION-based SQL injection', () => {
-      const unionInjection = "' UNION SELECT * FROM users --";
-
-      expect(() => {
-        sanitizeString(unionInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block boolean-based SQL injection', () => {
-      const booleanInjection = "' OR '1'='1";
-
-      expect(() => {
-        sanitizeString(booleanInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block time-based SQL injection', () => {
-      const timeInjection = "'; WAITFOR DELAY '00:00:05' --";
-
-      expect(() => {
-        sanitizeString(timeInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('Command Injection Protection', () => {
-    it('should block command injection attempts', () => {
-      const commandInjection = '; rm -rf /';
-
-      expect(() => {
-        sanitizeString(commandInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block pipe command injection', () => {
-      const pipeInjection = '| cat /etc/passwd';
-
-      expect(() => {
-        sanitizeString(pipeInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block backtick command injection', () => {
-      const backtickInjection = '`whoami`';
-
-      expect(() => {
-        sanitizeString(backtickInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block $() command injection', () => {
-      const dollarInjection = '$(curl malicious.com)';
-
-      expect(() => {
-        sanitizeString(dollarInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('Path Traversal Protection', () => {
-    it('should block path traversal attempts', () => {
-      const pathTraversal = '../../../etc/passwd';
-
-      expect(() => {
-        sanitizeString(pathTraversal);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block encoded path traversal', () => {
-      const encodedTraversal = '%2e%2e%2f%2e%2e%2f%2e%2e%2fetc%2fpasswd';
-
-      expect(() => {
-        sanitizeString(encodedTraversal);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('LDAP Injection Protection', () => {
-    it('should block LDAP injection attempts', () => {
-      const ldapInjection = '*)(&';
-
-      expect(() => {
-        sanitizeString(ldapInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block LDAP filter injection', () => {
-      const ldapFilter = '*)(uid=*';
-
-      expect(() => {
-        sanitizeString(ldapFilter);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('NoSQL Injection Protection', () => {
-    it('should block NoSQL injection attempts', () => {
-      const nosqlInjection = '{"$gt":""}';
-
-      expect(() => {
-        sanitizeString(nosqlInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should block MongoDB operator injection', () => {
-      const mongoInjection = '{"$where":"this.password == \'admin\'"}';
-
-      expect(() => {
-        sanitizeString(mongoInjection);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('HTML Attribute Sanitization', () => {
-    it('should reject HTML content that contains tags', () => {
-      const htmlContent = '<div class="test">Content with & symbols</div>';
-
-      expect(() => {
-        sanitizeString(htmlContent);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should handle quotes and apostrophes correctly in safe content', () => {
-      const quoteContent = "Here are some quotes";
-
-      const result = sanitizeString(quoteContent);
-      expect(result).toBe('Here are some quotes'); // No special characters to escape
-    });
-
-    it('should reject dangerous HTML content', () => {
-      const dangerousContent = '</script><script>alert("XSS")</script>';
-
-      expect(() => {
-        sanitizeString(dangerousContent);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('Unicode and Encoding Attack Protection', () => {
-    it('should normalize and clean zero-width characters', () => {
-      const zeroWidthAttack = 'scr\u200bipt'; // script with zero-width space
-
-      // Should be normalized to 'script' and then detected as dangerous
-      expect(() => {
-        sanitizeString(zeroWidthAttack);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should normalize Unicode characters', () => {
-      const unicodeAttack = 's\u0307c\u0307r\u0307i\u0307p\u0307t'; // script with combining dots
-
-      // Should be normalized but the combining dots might not form 'script' exactly
-      // Let's verify that normalization occurs
-      const result = sanitizeString(unicodeAttack);
-      expect(typeof result).toBe('string');
-    });
-
-    it('should block mixed encoding attacks', () => {
-      const mixedEncoding = 'scr\\u0069pt'; // script using Unicode escape
-
-      expect(() => {
-        sanitizeString(mixedEncoding);
-      }).toThrow('contains potentially dangerous content');
-    });
-  });
-
-  describe('Content Security Policy Integration', () => {
-    it('should block inline event handlers completely', () => {
-      const inlineHandlers = [
-        'onclick="alert(1)"',
-        'onload="malicious()"',
-        'onerror="alert(1)"',
-        'onmouseover="exploit()"',
-        'onfocus="attack()"',
-        'onblur="compromise()"'
-      ];
-
-      inlineHandlers.forEach(handler => {
-        expect(() => {
-          sanitizeString(handler);
-        }).toThrow('contains potentially dangerous content');
-      });
-    });
-
-    it('should block dangerous HTML5 attributes', () => {
-      const dangerousAttrs = [
-        'autofocus onclick="alert(1)"',
-        'formaction="javascript:alert(1)"',
-        'poster="javascript:alert(1)"'
-      ];
-
-      dangerousAttrs.forEach(attr => {
-        expect(() => {
-          sanitizeString(attr);
-        }).toThrow('contains potentially dangerous content');
-      });
-    });
-  });
-
-  describe('JSON Security', () => {
-    it('should sanitize JSON strings safely', () => {
-      const maliciousJson = {
-        title: '<script>alert(1)</script>',
-        desc: 'test'
-      };
-
-      const result = safeJsonStringify(maliciousJson);
-      expect(result).not.toContain('<script>');
-    });
-
-    it('should reject malicious JSON parsing attempts', () => {
-      const maliciousJsonString = '{"title": "<script>alert(1)</script>"}';
-
-      // safeJsonParse validates as FilterExpression, which requires specific structure
-      // So it will fail due to missing required fields, not due to XSS detection
-      expect(() => {
-        safeJsonParse(maliciousJsonString);
-      }).toThrow(); // Should throw some validation error
-    });
-
-    it('should prevent prototype pollution in JSON', () => {
-      const pollutedJson = '{"__proto__": {"isAdmin": true}}';
-
-      expect(() => {
-        safeJsonParse(pollutedJson);
-      }).toThrow('contains potentially dangerous prototype pollution patterns');
-    });
-  });
-
-  describe('Array and Bulk Operation Security', () => {
-    it('should sanitize string arrays in bulk operations', () => {
-      const maliciousArray = [
-        'Task 1',
-        '<script>alert("XSS")</script>Task 2',
-        'Task 3'
-      ];
-
-      expect(() => {
-        validateValue(maliciousArray);
-      }).toThrow('contains potentially dangerous content');
-    });
-
-    it('should prevent injection in numeric arrays', () => {
-      const maliciousNumbers = [1, 2, '; DROP TABLE users; --', 4];
-
-      // Numeric arrays should reject non-numeric content
-      expect(() => {
-        validateValue(maliciousNumbers);
-      }).toThrow();
-    });
-
-    it('should limit array size to prevent DoS', () => {
-      const largeArray = new Array(101).fill('test'); // Exceeds 100 element limit
-
-      expect(() => {
-        validateValue(largeArray);
-      }).toThrow('cannot exceed 100 elements');
-    });
-  });
-
-  describe('Integration with Existing Security', () => {
-    it('should work alongside credential masking', () => {
-      const mixedContent = {
-        title: '<script>alert("XSS")</script>Task',
-        api_token: 'sk-secret123456789'
-      };
-
-      const sanitized = sanitizeLogData(mixedContent);
-
-      // XSS should be blocked/rejected by input sanitization
-      // Credentials should be masked by existing security
-      expect(sanitized).toEqual({
-        title: '[SANITIZATION_FAILED]', // Dangerous content rejected by sanitization
-        api_token: '[REDACTED]' // Masked credential
-      });
-    });
-
-    it('should maintain security in nested objects', () => {
-      const nestedMalicious = {
-        task: {
-          title: '<img src=x onerror=alert(1)>',
-          metadata: {
-            description: 'Normal text',
-            tags: ['<script>alert(1)</script>', 'normal']
-          }
+    it('rejects <script> regardless of case and attributes', () => {
+      ['<SCRIPT>', '<script src="x.js">', '<script type="x">', '</script>'].forEach(
+        (value) => {
+          expect(() => sanitizeString(value)).toThrow('dangerous content');
         },
-        secret: 'credential123456789'
-      };
+      );
+    });
 
-      const sanitized = sanitizeLogData(nestedMalicious);
-
-      // All dangerous content should be handled appropriately
-      expect(sanitized).toEqual({
-        task: {
-          title: '[SANITIZATION_FAILED]', // Dangerous content rejected
-          metadata: {
-            description: 'Normal text', // Safe content sanitized
-            tags: ['[SANITIZATION_FAILED]', 'normal'] // Array element sanitized
-          }
-        },
-        secret: '[REDACTED]' // Credential masked
+    it('rejects <iframe> tags', () => {
+      ['<iframe>', '<iframe src="evil">', '</iframe>'].forEach((value) => {
+        expect(() => sanitizeString(value)).toThrow('dangerous content');
       });
     });
+  });
+
+  describe('accepts legitimate task content (regression: over-restrictive filter)', () => {
+    it('accepts absolute, relative and Windows file paths', () => {
+      const paths = [
+        '/home/nico/docker/stacks/marea-mcp-vikunja/.env',
+        'src/utils/validation.ts',
+        'C:\\Users\\nicof\\Desktop',
+        'see ../sibling and ../../grandparent dirs',
+      ];
+      paths.forEach((path) => {
+        expect(() => sanitizeString(path)).not.toThrow();
+      });
+    });
+
+    it('accepts external (non-Google) URLs', () => {
+      const urls = [
+        'https://www.sortitionfoundation.org/our-work',
+        'https://example.com/path?a=1&b=2#frag',
+        'See https://docs.google.com/document/d/abc and https://github.com/x/y',
+      ];
+      urls.forEach((url) => {
+        expect(() => sanitizeString(url)).not.toThrow();
+      });
+    });
+
+    it('accepts prose containing SQL-like words', () => {
+      const prose = [
+        'Update the roadmap and drop the stale items',
+        'Select panelists, then create the press note',
+        'Delete old drafts -- they collide on subject',
+      ];
+      prose.forEach((text) => {
+        expect(() => sanitizeString(text)).not.toThrow();
+      });
+    });
+
+    it('accepts Markdown, punctuation and shell-tool names the old filter rejected', () => {
+      const inputs = [
+        '## Overview\n- item 1\n- item 2',
+        'Range: May 13--15 /* note */',
+        'Issue #12 and #19',
+        'The constructor and prototype of the class',
+        'Run wget, curl or ssh to fetch it',
+        '<!-- a plain note -->',
+      ];
+      inputs.forEach((text) => {
+        expect(() => sanitizeString(text)).not.toThrow();
+      });
+    });
+
+    it('accepts a long description well beyond the old 1000-char cap', () => {
+      const long = 'Detailed description sentence. '.repeat(500);
+      expect(long.length).toBeGreaterThan(1000);
+      expect(() => sanitizeString(long)).not.toThrow();
+    });
+  });
+
+  describe('length backstop', () => {
+    it('accepts strings up to MAX_STRING_LENGTH', () => {
+      expect(() => sanitizeString('a'.repeat(1_000_000))).not.toThrow();
+    });
+
+    it('rejects strings past the 1,000,000-char backstop', () => {
+      expect(() => sanitizeString('a'.repeat(1_000_001))).toThrow(
+        'exceeds maximum length of 1000000',
+      );
+    });
+  });
+
+  describe('HTML escaping', () => {
+    it('escapes HTML-significant characters instead of rejecting them', () => {
+      expect(sanitizeString('a < b && c > d')).toBe('a &lt; b &amp;&amp; c &gt; d');
+    });
+
+    it('escapes slashes (entities render correctly in the Vikunja HTML field)', () => {
+      expect(sanitizeString('path/to/file')).toBe('path&#x2F;to&#x2F;file');
+    });
+
+    it('strips zero-width / invisible characters', () => {
+      expect(sanitizeString('he​llo')).toBe('hello');
+    });
+  });
+});
+
+describe('validateValue propagates sanitizeString to array elements', () => {
+  it('sanitizes ordinary string array elements without rejecting them', () => {
+    const result = validateValue(['Task 1', 'path/to/x', 'Task 3']);
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as string[]).length).toBe(3);
+  });
+
+  it('still rejects <script> inside an array element', () => {
+    expect(() => validateValue(['ok', '<script>alert(1)</script>'])).toThrow(
+      'dangerous content',
+    );
+  });
+});
+
+describe('safeJsonParse prototype-pollution protection', () => {
+  it('rejects __proto__ payloads', () => {
+    expect(() => safeJsonParse('{"__proto__": {"isAdmin": true}}')).toThrow(
+      'prototype pollution',
+    );
+  });
+});
+
+describe('sanitizeLogData integration', () => {
+  it('escapes ordinary strings rather than failing on paths/prose', () => {
+    const out = sanitizeLogData({ note: 'see /home/nico/docker' }) as Record<
+      string,
+      string
+    >;
+    expect(out.note).not.toBe('[SANITIZATION_FAILED]');
+    expect(typeof out.note).toBe('string');
+  });
+
+  it('falls back to [SANITIZATION_FAILED] on script injection', () => {
+    const out = sanitizeLogData({ title: '<script>alert(1)</script>' }) as Record<
+      string,
+      string
+    >;
+    expect(out.title).toBe('[SANITIZATION_FAILED]');
   });
 });

--- a/tests/utils/input-sanitization.test.ts
+++ b/tests/utils/input-sanitization.test.ts
@@ -6,7 +6,9 @@
  * filesystem or LDAP/NoSQL sink behind it. It therefore:
  *   - rejects values past MAX_STRING_LENGTH (a generous DoS backstop)
  *   - rejects unambiguous <script>/<iframe> HTML injection
- *   - HTML-escapes everything else (the Vikunja description field is HTML)
+ *   - normalizes Unicode and strips invisible spoofing characters, but does
+ *     NOT HTML-escape: Vikunja owns rendering (plain-text title, and it
+ *     sanitizes the description HTML itself)
  *
  * These tests double as regression coverage for the previously over-broad
  * blocklist, which wrongly rejected file paths, external URLs and ordinary
@@ -111,13 +113,27 @@ describe('sanitizeString', () => {
     });
   });
 
-  describe('HTML escaping', () => {
-    it('escapes HTML-significant characters instead of rejecting them', () => {
-      expect(sanitizeString('a < b && c > d')).toBe('a &lt; b &amp;&amp; c &gt; d');
+  describe('passes content through without escaping', () => {
+    it('does not escape HTML-significant characters', () => {
+      expect(sanitizeString('a < b && c > d')).toBe('a < b && c > d');
     });
 
-    it('escapes slashes (entities render correctly in the Vikunja HTML field)', () => {
-      expect(sanitizeString('path/to/file')).toBe('path&#x2F;to&#x2F;file');
+    it('does not escape slashes (the task title is a plain-text field)', () => {
+      expect(sanitizeString('fix src/utils/validation.ts')).toBe(
+        'fix src/utils/validation.ts',
+      );
+    });
+
+    it('does not rewrite path-traversal substrings', () => {
+      const paths = [
+        '../config',
+        'see ../../etc/hosts and /etc/passwd',
+        'C:\\Windows\\System32',
+        '%2e%2e/secret',
+      ];
+      paths.forEach((path) => {
+        expect(sanitizeString(path)).toBe(path);
+      });
     });
 
     it('strips zero-width / invisible characters', () => {
@@ -149,7 +165,7 @@ describe('safeJsonParse prototype-pollution protection', () => {
 });
 
 describe('sanitizeLogData integration', () => {
-  it('escapes ordinary strings rather than failing on paths/prose', () => {
+  it('passes ordinary strings through rather than failing on paths/prose', () => {
     const out = sanitizeLogData({ note: 'see /home/nico/docker' }) as Record<
       string,
       string

--- a/tests/utils/label-bulk.test.ts
+++ b/tests/utils/label-bulk.test.ts
@@ -1,0 +1,30 @@
+import { setTaskLabels } from '../../src/utils/label-bulk';
+
+describe('setTaskLabels', () => {
+  it('sends the { labels: [{ id }] } body shape that Vikunja requires', async () => {
+    const updateTaskLabels = jest.fn().mockResolvedValue({});
+    const client = { tasks: { updateTaskLabels } };
+
+    await setTaskLabels(client as never, 42, [3, 8]);
+
+    expect(updateTaskLabels).toHaveBeenCalledWith(42, {
+      labels: [{ id: 3 }, { id: 8 }],
+    });
+  });
+
+  it('sends an empty labels array to clear every label', async () => {
+    const updateTaskLabels = jest.fn().mockResolvedValue({});
+    const client = { tasks: { updateTaskLabels } };
+
+    await setTaskLabels(client as never, 7, []);
+
+    expect(updateTaskLabels).toHaveBeenCalledWith(7, { labels: [] });
+  });
+
+  it('propagates errors from the API client', async () => {
+    const updateTaskLabels = jest.fn().mockRejectedValue(new Error('boom'));
+    const client = { tasks: { updateTaskLabels } };
+
+    await expect(setTaskLabels(client as never, 1, [1])).rejects.toThrow('boom');
+  });
+});

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -50,55 +50,60 @@ describe('Security Validation Utilities', () => {
       expect(() => sanitizeString([])).toThrow(MCPError);
     });
 
-    it('should throw error for strings exceeding maximum length', () => {
-      const longString = 'a'.repeat(1001);
-      expect(() => sanitizeString(longString)).toThrow(
-        new MCPError(ErrorCode.VALIDATION_ERROR, 'String value exceeds maximum length of 1000')
+    it('should accept long strings well beyond the old 1000-char limit', () => {
+      const longDescription = 'a'.repeat(10000);
+      expect(sanitizeString(longDescription)).toBe(longDescription);
+    });
+
+    it('should throw error for strings exceeding the 1,000,000-char backstop', () => {
+      const hugeString = 'a'.repeat(1_000_001);
+      expect(() => sanitizeString(hugeString)).toThrow(
+        new MCPError(ErrorCode.VALIDATION_ERROR, 'String value exceeds maximum length of 1000000')
       );
     });
 
-    it('should detect and block XSS patterns', () => {
+    it('should still block unambiguous script/iframe injection', () => {
       const xssPatterns = [
         '<script>',
         '<SCRIPT>',
-        '<img src=x onerror=alert(1)>',
-        '<body onload=alert(1)>',
-        'javascript:alert(1)',
-        'JAVASCRIPT:alert(1)',
+        '<script src="evil.js">',
+        '</script>',
         '<iframe>',
-        '<object>',
-        '<embed>',
-        '<link>',
-        '<meta>',
-        '<style>',
-        '<svg>',
-        '<!-- malicious script -->',
-        'expression(alert(1))',
-        'eval("malicious")',
-        'Function("malicious")',
-        '<div onmouseover="alert(1)">',
-        '<a href="javascript:alert(1)">',
-        'data:text/html,<script>alert(1)</script>',
-        'data:application/javascript,alert(1)'
+        '<iframe src="evil">',
+        'data:text/html,<script>alert(1)</script>'
       ];
 
-      // Test that all patterns throw errors
-      xssPatterns.forEach((pattern, index) => {
+      xssPatterns.forEach((pattern) => {
         expect(() => sanitizeString(pattern)).toThrow(MCPError);
       });
     });
 
-    it('should detect XSS in HTML-encoded content', () => {
-      const encodedXss = [
-        '&lt;script&gt;alert(1)&lt;&#x2F;script&gt;',
-        '&lt;img src=x onerror=alert(1)&gt;',
-        '&lt;iframe&gt;',
-        '&lt;svg&gt;'
+    it('should accept content the old over-broad blocklist wrongly rejected', () => {
+      // Normal task content that must round-trip (escaped), never be rejected.
+      const safeButPreviouslyRejected = [
+        '<object>',
+        '<style>',
+        '<svg>',
+        '<!-- a note -->',
+        'expression(alert(1))',
+        'eval the results',
+        '<div onmouseover="x">',
+        'data:application/json,{}'
       ];
 
-      encodedXss.forEach(pattern => {
-        expect(() => sanitizeString(pattern)).toThrow(MCPError);
-        expect(() => sanitizeString(pattern)).toThrow('String contains potentially dangerous content');
+      safeButPreviouslyRejected.forEach((input) => {
+        expect(() => sanitizeString(input)).not.toThrow();
+      });
+    });
+
+    it('should accept already-HTML-encoded content (it is inert text)', () => {
+      const encoded = [
+        '&lt;script&gt;alert(1)&lt;&#x2F;script&gt;',
+        '&lt;iframe&gt;'
+      ];
+
+      encoded.forEach(pattern => {
+        expect(() => sanitizeString(pattern)).not.toThrow();
       });
     });
 
@@ -713,15 +718,10 @@ describe('Security Validation Utilities', () => {
   });
 
   describe('XSS Protection', () => {
-    it('should reject dangerous content with StorageDataError', () => {
-      // Current security approach: reject dangerous content rather than sanitize
+    it('should reject script and iframe injection', () => {
       const dangerousInputs = [
         '<script>alert("xss")</script>',
-        'javascript:alert("xss")',
-        '<img src=x onerror=alert("xss")>',
-        '<svg onload=alert("xss")>',
-        '<iframe src="evil.com"></iframe>',
-        'onload="alert(1)"'
+        '<iframe src="evil.com"></iframe>'
       ];
 
       dangerousInputs.forEach(input => {

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -29,16 +29,18 @@ describe('Security Validation Utilities', () => {
       expect(result).toBe('This is a valid string');
     });
 
-    it('should escape HTML special characters (when not XSS)', () => {
-      const testCases = [
-        { input: 'Hello <world>', expected: 'Hello &lt;world&gt;' },
-        { input: 'Test "quoted" string', expected: 'Test &quot;quoted&quot; string' },
-        { input: "Test 'single' quotes", expected: 'Test &#x27;single&#x27; quotes' },
-        { input: 'path/to/file', expected: 'path&#x2F;to&#x2F;file' }
+    it('should not HTML-escape special characters (Vikunja owns rendering)', () => {
+      const passthrough = [
+        'Hello <world>',
+        'Test "quoted" string',
+        "Test 'single' quotes",
+        'fix src/utils/validation.ts',
+        'key=value & other=thing',
+        'use `backticks` and C:\\paths',
       ];
 
-      testCases.forEach(({ input, expected }) => {
-        expect(sanitizeString(input)).toBe(expected);
+      passthrough.forEach((input) => {
+        expect(sanitizeString(input)).toBe(input);
       });
     });
 
@@ -729,14 +731,10 @@ describe('Security Validation Utilities', () => {
       });
     });
 
-    it('should escape safe HTML content', () => {
-      // Test that safe HTML tags are escaped rather than stripped
+    it('should pass safe HTML tags through unescaped', () => {
+      // Vikunja sanitizes description HTML itself; the wrapper does not escape.
       const safeInput = '<b>Bold text</b><em>Emphasis</em>';
-      const result = sanitizeString(safeInput);
-      // HTML entities should be escaped
-      expect(result).toContain('&lt;b&gt;');
-      expect(result).toContain('&lt;em&gt;');
-      expect(typeof result).toBe('string');
+      expect(sanitizeString(safeInput)).toBe(safeInput);
     });
   });
 });

--- a/tests/utils/vikunja-rest.test.ts
+++ b/tests/utils/vikunja-rest.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for the direct Vikunja REST helper.
+ *
+ * Covers vikunjaRestRequest (URL normalization, body handling, HTTP errors,
+ * network errors, empty/non-JSON bodies) and resolveKanbanViewId.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AuthManager } from '../../src/auth/AuthManager';
+import { vikunjaRestRequest, resolveKanbanViewId } from '../../src/utils/vikunja-rest';
+import { MCPError, ErrorCode } from '../../src/types';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/**
+ * Builds a minimal Response-like object good enough for vikunjaRestRequest,
+ * which only reads `.ok`, `.status`, `.statusText` and `.text()`.
+ */
+function mockResponse(opts: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  text?: string;
+  textThrows?: boolean;
+}): Response {
+  const {
+    ok = true,
+    status = 200,
+    statusText = 'OK',
+    text = '',
+    textThrows = false,
+  } = opts;
+  return {
+    ok,
+    status,
+    statusText,
+    text: textThrows
+      ? jest.fn(async () => {
+          throw new Error('stream read error');
+        })
+      : jest.fn(async () => text),
+  } as unknown as Response;
+}
+
+describe('vikunja-rest helper', () => {
+  let authManager: AuthManager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    authManager = new AuthManager();
+    authManager.connect('https://vikunja.test', 'tk_test-token');
+  });
+
+  describe('vikunjaRestRequest', () => {
+    it('performs a GET request and parses the JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify({ id: 7 }) }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/tasks/7');
+
+      expect(result).toEqual({ id: 7 });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      // apiUrl had no /api/v1 prefix, so it must have been appended.
+      expect(url).toBe('https://vikunja.test/api/v1/tasks/7');
+      expect(init.method).toBe('GET');
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        'Bearer tk_test-token',
+      );
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+        'application/json',
+      );
+      // No body when none is supplied.
+      expect(init.body).toBeUndefined();
+    });
+
+    it('serializes the body as JSON when one is provided', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      await vikunjaRestRequest(authManager, 'POST', '/things', { a: 1 });
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ a: 1 }));
+    });
+
+    it('does not normalize an apiUrl that already includes the /api/v1 prefix', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/api/v1', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects/4/views');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/4/views');
+    });
+
+    it('strips a trailing slash from the apiUrl before building the URL', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects');
+    });
+
+    it('recognizes an /api/v2 versioned root', async () => {
+      authManager = new AuthManager();
+      authManager.connect('https://vikunja.test/api/v2', 'tk_token');
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '[]' }));
+
+      await vikunjaRestRequest(authManager, 'GET', '/projects');
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v2/projects');
+    });
+
+    it('returns null when the response body is empty', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/empty');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the response body is not valid JSON', async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: 'not json at all' }));
+
+      const result = await vikunjaRestRequest(authManager, 'GET', '/weird');
+
+      expect(result).toBeNull();
+    });
+
+    it('throws an MCPError when fetch rejects (network error)', async () => {
+      // Persistent rejection: this test makes two assertion calls.
+      mockFetch.mockRejectedValue(new Error('connection refused'));
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(MCPError);
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): connection refused',
+      );
+    });
+
+    it('includes the error code API_ERROR on network failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('boom'));
+
+      try {
+        await vikunjaRestRequest(authManager, 'GET', '/tasks/1');
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.API_ERROR);
+      }
+    });
+
+    it('stringifies a non-Error rejection value', async () => {
+      mockFetch.mockRejectedValueOnce('plain string failure');
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): plain string failure',
+      );
+    });
+
+    it('throws an MCPError with the response detail when the response is not OK', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: 'task does not exist',
+        }),
+      );
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/999'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/999): HTTP 404 Not Found — task does not exist',
+      );
+    });
+
+    it('omits the detail suffix when the error body is empty', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          text: '',
+        }),
+      );
+
+      try {
+        await vikunjaRestRequest(authManager, 'POST', '/things');
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect((error as MCPError).message).toBe(
+          'Vikunja REST request failed (POST /things): HTTP 500 Internal Server Error',
+        );
+      }
+    });
+
+    it('truncates an oversized error body to 500 characters', async () => {
+      const longBody = 'x'.repeat(2000);
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: longBody,
+        }),
+      );
+
+      try {
+        await vikunjaRestRequest(authManager, 'GET', '/tasks/1');
+        throw new Error('should have thrown');
+      } catch (error) {
+        const message = (error as MCPError).message;
+        // 500 chars of 'x' should be present, but not the full 2000.
+        expect(message).toContain('x'.repeat(500));
+        expect(message).not.toContain('x'.repeat(501));
+      }
+    });
+
+    it('falls back to the status line when the error body cannot be read', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 502,
+          statusText: 'Bad Gateway',
+          textThrows: true,
+        }),
+      );
+
+      await expect(
+        vikunjaRestRequest(authManager, 'GET', '/tasks/1'),
+      ).rejects.toThrow(
+        'Vikunja REST request failed (GET /tasks/1): HTTP 502 Bad Gateway',
+      );
+    });
+  });
+
+  describe('resolveKanbanViewId', () => {
+    it('returns the id of the Kanban view when one exists', async () => {
+      const views = [
+        { id: 10, title: 'List', project_id: 4, view_kind: 'list' },
+        { id: 11, title: 'Kanban', project_id: 4, view_kind: 'kanban' },
+        { id: 12, title: 'Gantt', project_id: 4, view_kind: 'gantt' },
+      ];
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify(views) }));
+
+      const viewId = await resolveKanbanViewId(authManager, 4);
+
+      expect(viewId).toBe(11);
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toBe('https://vikunja.test/api/v1/projects/4/views');
+    });
+
+    it('throws NOT_FOUND when the project has no Kanban view', async () => {
+      const views = [{ id: 10, title: 'List', project_id: 4, view_kind: 'list' }];
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: JSON.stringify(views) }));
+
+      await expect(resolveKanbanViewId(authManager, 4)).rejects.toThrow(
+        new MCPError(
+          ErrorCode.NOT_FOUND,
+          'Project 4 has no Kanban view, so it has no buckets',
+        ),
+      );
+    });
+
+    it('throws NOT_FOUND when the views response is not an array', async () => {
+      // A 2xx non-JSON body resolves to null inside vikunjaRestRequest.
+      mockFetch.mockResolvedValueOnce(mockResponse({ text: '' }));
+
+      try {
+        await resolveKanbanViewId(authManager, 9);
+        throw new Error('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MCPError);
+        expect((error as MCPError).code).toBe(ErrorCode.NOT_FOUND);
+        expect((error as MCPError).message).toBe(
+          'Project 9 has no Kanban view, so it has no buckets',
+        );
+      }
+    });
+
+    it('propagates an MCPError raised by the underlying request', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ ok: false, status: 403, statusText: 'Forbidden', text: 'nope' }),
+      );
+
+      await expect(resolveKanbanViewId(authManager, 4)).rejects.toThrow(MCPError);
+    });
+  });
+});


### PR DESCRIPTION
## What

`sanitizeString` (`src/utils/validation.ts`) was too aggressive on task titles and descriptions.

1. A 1000-character cap rejected longer descriptions. Vikunja does not cap description length (the column is a longtext). Raised to 1,000,000 as a pure DoS backstop.
2. An ~180-pattern "dangerous content" blocklist (SQL, shell, path traversal, LDAP, NoSQL, prototype-pollution) rejected legitimate content: file paths, external URLs, `#`, `--`, prose with words like "select" or "update". These values are only ever sent to the Vikunja REST API as JSON field values, never interpolated into SQL, a shell, a filesystem path or an LDAP/NoSQL query, so the blocklist had no sink to protect. Reduced to literal `<script>`/`<iframe>` rejection.
3. The function also HTML-escaped its output (`/` to `&#x2F;`, etc.) and rewrote `../` to `...`. Task titles are a plain-text field in Vikunja, so escaped slashes displayed literally, and the `../` rewrite corrupted relative paths. Step 2 now only normalizes Unicode (NFC) and strips invisible/zero-width characters.

The validation and input-sanitization test suites are realigned to the new contract.

## Notes

Stacked on #47 and the label fix. Until those merge the diff also shows their commits; review only `1c4f40e`, `5311b16`.

Verified end to end against a live Vikunja instance: a created task round-trips a multi-thousand-character description containing file paths and external URLs unchanged.