### PR TITLE
feat: add percentDone support to task update

### DIFF
--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -20,6 +20,7 @@ export interface UpdateTaskArgs {
   description?: string;
   dueDate?: string;
   priority?: number;
+  percentDone?: number;
   done?: boolean;
   labels?: number[];
   assignees?: number[];
@@ -135,6 +136,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   if (currentTask.due_date !== undefined) previousState.due_date = currentTask.due_date;
   if (currentTask.priority !== undefined) previousState.priority = currentTask.priority;
   if (currentTask.done !== undefined) previousState.done = currentTask.done;
+  if (currentTask.percent_done !== undefined) previousState.percent_done = currentTask.percent_done;
   if (currentTask.repeat_after !== undefined) previousState.repeat_after = currentTask.repeat_after;
   if (currentTask.repeat_mode !== undefined) previousState.repeat_mode = currentTask.repeat_mode;
 
@@ -145,6 +147,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   if (args.description !== undefined && args.description !== currentTask.description) affectedFields.push('description');
   if (args.dueDate !== undefined && args.dueDate !== currentTask.due_date) affectedFields.push('dueDate');
   if (args.priority !== undefined && args.priority !== currentTask.priority) affectedFields.push('priority');
+  if (args.percentDone !== undefined && args.percentDone !== currentTask.percent_done) affectedFields.push('percentDone');
   if (args.done !== undefined && args.done !== currentTask.done) affectedFields.push('done');
   if (args.repeatAfter !== undefined && args.repeatAfter !== currentTask.repeat_after) affectedFields.push('repeatAfter');
   if (args.repeatMode !== undefined && args.repeatMode !== currentTask.repeat_mode) affectedFields.push('repeatMode');
@@ -170,6 +173,7 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
     ...(args.description !== undefined && { description: args.description }),
     ...(args.dueDate !== undefined && { due_date: args.dueDate }),
     ...(args.priority !== undefined && { priority: args.priority }),
+    ...(args.percentDone !== undefined && { percent_done: args.percentDone }),
     ...(args.done !== undefined && { done: args.done }),
     // Handle repeat configuration for updates
     ...(args.repeatAfter !== undefined || args.repeatMode !== undefined

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -153,6 +153,7 @@ export function registerTasksTool(
       projectId: z.number().optional(),
       dueDate: z.string().optional(),
       priority: z.number().min(0).max(5).optional(),
+      percentDone: z.number().min(0).max(1).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
       // Recurring task fields

--- a/tests/tools/tasks.test.ts
+++ b/tests/tools/tasks.test.ts
@@ -710,6 +710,7 @@ describe('Tasks Tool', () => {
         description: 'Updated Description',
         dueDate: '2025-01-01T00:00:00Z',
         priority: 3,
+        percentDone: 0.5,
         done: true,
       };
       mockClient.tasks.getTask.mockResolvedValueOnce(mockTask).mockResolvedValueOnce(updatedTask);
@@ -721,6 +722,7 @@ describe('Tasks Tool', () => {
         description: 'Updated Description',
         dueDate: '2025-01-01T00:00:00Z',
         priority: 3,
+        percentDone: 0.5,
         done: true,
       });
 
@@ -730,6 +732,7 @@ describe('Tasks Tool', () => {
         description: 'Updated Description',
         due_date: '2025-01-01T00:00:00Z',
         priority: 3,
+        percent_done: 0.5,
         done: true,
       });
 


### PR DESCRIPTION
## Summary

Add `percentDone` parameter to the task update subcommand, allowing AI assistants to set task progress percentages (0.0 to 1.0) via the MCP.

The Vikunja API already supports `percent_done` but the MCP server did not expose it.

## Changes

- **`src/tools/tasks/index.ts`**: Add `percentDone: z.number().min(0).max(1).optional()` to the Zod schema
- **`src/tools/tasks/crud/TaskUpdateService.ts`**: Add `percentDone` to `UpdateTaskArgs` interface, `analyzeUpdateState` tracking, `affectedFields`, and `buildUpdateData` mapping to `percent_done`
- **`tests/tools/tasks.test.ts`**: Add `percentDone: 0.5` to the "update with all optional fields" test case

## Why

Without this, there is no way to set a task's progress percentage via the MCP. Users (and AI assistants) can only mark tasks as done (boolean), missing the granularity of partial progress (0-100%). This is especially useful for tracking work-in-progress tasks.