### PR TITLE
fix(bulk-update): preserve fields via per-task merge (fixes #46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ vikunja_tasks.bulk-create({
 })
 
 // Bulk update multiple tasks with the same field value
+// (fetch+merge per task — safe against Vikunja full-replace field wipes)
 vikunja_tasks.bulk-update({
   taskIds: [123, 124, 125],
   field: "done",          // Field to update
@@ -1027,7 +1028,8 @@ This standardized format ensures:
     - Required: taskIds array, field name, value
     - Supported fields: done, priority, due_date, project_id, assignees, labels
     - Validates field types and values
-    - ⚠️ Performance: Makes API calls to fetch each updated task
+    - Uses per-task fetch+merge+update (does not call Vikunja's native bulk API, which can wipe omitted fields — see #46)
+    - ⚠️ Performance: O(n) get+update calls (n = number of tasks)
   - `bulk-delete` - Delete multiple tasks at once
     - Required: taskIds array
     - Returns deleted task details for confirmation

--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -47,100 +47,76 @@ const successResponse = (op: string, msg: string, tasks: Task[], meta: Record<st
   content: [{ type: 'text' as const, text: formatAorpAsMarkdown(createStandardResponse(op, msg, { tasks }, { timestamp: new Date().toISOString(), ...meta })) }]
 });
 
+/**
+ * Resolve bulk-update field value for Vikunja's updateTask payload.
+ * Native bulk API used a numeric repeat_mode map; keep that conversion when merging.
+ */
+function resolveBulkUpdateValue(field: string | undefined, value: unknown): unknown {
+  if (field === 'repeat_mode' && typeof value === 'string') {
+    return REPEAT_MODE_MAP[value] ?? value;
+  }
+  return value;
+}
+
 // ==================== BULK UPDATE ====================
 
+/**
+ * Bulk-update via per-task GET + merge + POST.
+ *
+ * Intentionally does **not** call Vikunja's native `bulkUpdateTasks` API.
+ * That endpoint only sends `{ task_ids, field, value }`, and Vikunja's task
+ * update semantics are a full-model replace — omitted fields (description,
+ * priority, etc.) get cleared. Using the merge path matches single-task
+ * `update` and avoids silent data loss (see GitHub issue #46).
+ */
 export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
   try {
     validateBulkUpdate(args);
     // Validation ensures taskIds exists
     const taskIds = args.taskIds ?? [];
     const client = await getClientFromContext();
+    const fieldValue = resolveBulkUpdateValue(args.field, args.value);
 
-    const updateWithFallback = async (): Promise<{ content: Array<{ type: 'text'; text: string }> }> => {
-      const updateResult = await processors.update.processBatches(taskIds, async (taskId) => {
-        const current = await client.tasks.getTask(taskId);
-        const update = applyFieldUpdate({ ...current }, args.field, args.value);
+    const updateResult = await processors.update.processBatches(taskIds, async (taskId) => {
+      const current = await client.tasks.getTask(taskId);
+      // Spread current task so fields not being changed survive Vikunja's full replace
+      const update = applyFieldUpdate({ ...current }, args.field, fieldValue);
 
-        const updated = await client.tasks.updateTask(taskId, update);
+      const updated = await client.tasks.updateTask(taskId, update);
 
-        if (args.field === 'assignees' && Array.isArray(args.value)) {
-          const currentAssignees = (await client.tasks.getTask(taskId)).assignees?.map((a: Assignee) => a.id) || [];
-          if (args.value.length > 0) {
-            try {
-              await withRetry(() => client.tasks.bulkAssignUsersToTask(taskId, { user_ids: args.value as number[] }), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
-            } catch (assigneeError) {
-              if (isAuthenticationError(assigneeError)) throw new MCPError(ErrorCode.API_ERROR, 'Assignee operations may have authentication issues');
-              throw assigneeError;
-            }
-          }
-          for (const userId of currentAssignees) {
-            try { await withRetry(() => client.tasks.removeUserFromTask(taskId, userId), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError }); }
-            catch (e) { if (isAuthenticationError(e)) throw new MCPError(ErrorCode.API_ERROR, `${AUTH_ERROR_MESSAGES.ASSIGNEE_REMOVE_PARTIAL} (Retried ${RETRY_CONFIG.AUTH_ERRORS.maxRetries} times)`); throw e; }
+      if (args.field === 'assignees' && Array.isArray(args.value)) {
+        const currentAssignees = (await client.tasks.getTask(taskId)).assignees?.map((a: Assignee) => a.id) || [];
+        if (args.value.length > 0) {
+          try {
+            await withRetry(() => client.tasks.bulkAssignUsersToTask(taskId, { user_ids: args.value as number[] }), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
+          } catch (assigneeError) {
+            if (isAuthenticationError(assigneeError)) throw new MCPError(ErrorCode.API_ERROR, 'Assignee operations may have authentication issues');
+            throw assigneeError;
           }
         }
-        if (args.field === 'labels' && Array.isArray(args.value)) {
-          await withRetry(() => client.tasks.updateTaskLabels(taskId, { label_ids: args.value as number[] }), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
-        }
-        return updated;
-      });
-
-      if (updateResult.failed.length > 0 && updateResult.successful.length === 0) {
-        const firstError = updateResult.failed[0]?.error;
-        // Preserve MCPError instances with auth messages
-        if (firstError instanceof MCPError && firstError.message.includes('authentication')) throw firstError;
-        throw new MCPError(ErrorCode.API_ERROR, `Bulk update failed. Could not update any tasks. Failed IDs: ${updateResult.failed.map(f => f.originalItem).join(', ')}`);
-      }
-      return successResponse('update-task', `Successfully updated ${taskIds.length} tasks`, updateResult.successful, {
-        count: taskIds.length, affectedFields: [args.field], performanceMetrics: {
-          totalDuration: updateResult.metrics.totalDuration, operationsPerSecond: updateResult.metrics.operationsPerSecond,
-          apiCallsUsed: updateResult.metrics.successfulOperations + updateResult.metrics.failedOperations,
-        },
-      });
-    };
-
-    try {
-      if (!args.field) throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Field required');
-      const bulkOp = { task_ids: taskIds, field: args.field, value: args.value };
-      if (args.field === 'repeat_mode' && typeof args.value === 'string') {
-        bulkOp.value = REPEAT_MODE_MAP[args.value] ?? args.value;
-      }
-
-      const result = await client.tasks.bulkUpdateTasks(bulkOp);
-      let updatedTasks: Task[] = [];
-      let shouldFallback = false;
-
-      if (Array.isArray(result) && result.length > 0) {
-        const isValid = result.every(t => t && typeof t === 'object' && 'project_id' in t && 'title' in t);
-        let hasValue = true;
-        if (args.field && ['priority', 'done', 'due_date', 'project_id'].includes(args.field)) {
-          hasValue = result.every(t => t[args.field as keyof Task] === args.value);
-        }
-        if (isValid && hasValue) {
-          updatedTasks = result;
-        } else if (isValid && !hasValue) {
-          // API returned success but values weren't updated - trigger fallback
-          shouldFallback = true;
+        for (const userId of currentAssignees) {
+          try { await withRetry(() => client.tasks.removeUserFromTask(taskId, userId), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError }); }
+          catch (e) { if (isAuthenticationError(e)) throw new MCPError(ErrorCode.API_ERROR, `${AUTH_ERROR_MESSAGES.ASSIGNEE_REMOVE_PARTIAL} (Retried ${RETRY_CONFIG.AUTH_ERRORS.maxRetries} times)`); throw e; }
         }
       }
-
-      // If we have valid updated tasks and no fallback needed, return success
-      if (updatedTasks.length > 0 && !shouldFallback) {
-        return successResponse('update-task', `Successfully updated ${taskIds.length} tasks`, updatedTasks, { count: taskIds.length, affectedFields: [args.field] });
+      if (args.field === 'labels' && Array.isArray(args.value)) {
+        await withRetry(() => client.tasks.updateTaskLabels(taskId, { label_ids: args.value as number[] }), { ...RETRY_CONFIG.AUTH_ERRORS, shouldRetry: isAuthenticationError });
       }
+      return updated;
+    });
 
-      if (shouldFallback) {
-        logger.warn('Bulk update API returned success but values not updated, falling back to individual updates');
-        return await updateWithFallback();
-      }
-
-      const fetchResult = await processors.update.processBatches(taskIds, async (id) => await client.tasks.getTask(id));
-      return successResponse('update-task', `Successfully updated ${taskIds.length} tasks${fetchResult.failed.length > 0 ? ` (${fetchResult.failed.length} could not be fetched)` : ''}`, fetchResult.successful, {
-        count: taskIds.length, affectedFields: [args.field], ...(fetchResult.failed.length > 0 && { fetchErrors: fetchResult.failed.length }),
-      });
-    } catch (bulkError) {
-      logger.warn('Bulk API failed, using fallback', { error: (bulkError as Error).message });
-      return await updateWithFallback();
+    if (updateResult.failed.length > 0 && updateResult.successful.length === 0) {
+      const firstError = updateResult.failed[0]?.error;
+      // Preserve MCPError instances with auth messages
+      if (firstError instanceof MCPError && firstError.message.includes('authentication')) throw firstError;
+      throw new MCPError(ErrorCode.API_ERROR, `Bulk update failed. Could not update any tasks. Failed IDs: ${updateResult.failed.map(f => f.originalItem).join(', ')}`);
     }
+    return successResponse('update-task', `Successfully updated ${taskIds.length} tasks`, updateResult.successful, {
+      count: taskIds.length, affectedFields: [args.field], performanceMetrics: {
+        totalDuration: updateResult.metrics.totalDuration, operationsPerSecond: updateResult.metrics.operationsPerSecond,
+        apiCallsUsed: updateResult.metrics.successfulOperations + updateResult.metrics.failedOperations,
+      },
+    });
   } catch (error) {
     if (error instanceof MCPError) throw error;
     if (error instanceof Error && (error.message.includes('fetch failed') || error.message.includes('ECONNREFUSED') || error.message.includes('ENOTFOUND'))) throw handleFetchError(error, 'bulk update tasks');

--- a/tests/tools/tasks.test.ts
+++ b/tests/tools/tasks.test.ts
@@ -1445,14 +1445,17 @@ describe('Tasks Tool', () => {
       mockClient.tasks.updateTaskLabels = jest.fn().mockResolvedValue({});
     });
 
-    it('should bulk update multiple tasks', async () => {
+    it('should bulk update multiple tasks via per-task merge (never native bulk API)', async () => {
       const taskIds = [1, 2, 3];
       mockClient.tasks.getTask.mockImplementation((id: number) =>
-        Promise.resolve({ ...mockTask, id, done: true }),
+        Promise.resolve({
+          ...mockTask,
+          id,
+          description: `desc ${id}`,
+          priority: 4,
+          done: false,
+        }),
       );
-
-      // Mock the bulk update API to return success
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
 
       const result = await callTool('bulk-update', {
         taskIds,
@@ -1460,19 +1463,17 @@ describe('Tasks Tool', () => {
         value: true,
       });
 
-      // Should call bulk update API with correct parameters
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledTimes(1);
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2, 3],
-        field: 'done',
-        value: true,
-      });
-
-      // Should fetch updated tasks after bulk update
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
       expect(mockClient.tasks.getTask).toHaveBeenCalledTimes(3);
-      expect(mockClient.tasks.getTask).toHaveBeenCalledWith(1);
-      expect(mockClient.tasks.getTask).toHaveBeenCalledWith(2);
-      expect(mockClient.tasks.getTask).toHaveBeenCalledWith(3);
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(3);
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          description: 'desc 1',
+          priority: 4,
+          done: true,
+        }),
+      );
 
       const markdown = result.content[0].text;
       const parsed = parseMarkdown(markdown);
@@ -1480,34 +1481,66 @@ describe('Tasks Tool', () => {
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('update-task');
       expect(markdown).toContain('Successfully updated 3 tasks');
-      expect(tasksData.tasks).toHaveLength(3);
+    });
+
+    it('should preserve description and priority when bulk-marking done (issue #46)', async () => {
+      mockClient.tasks.getTask.mockImplementation((id: number) =>
+        Promise.resolve({
+          ...mockTask,
+          id,
+          description: 'important notes',
+          priority: 3,
+          done: false,
+        }),
+      );
+
+      await callTool('bulk-update', {
+        taskIds: [10, 11],
+        field: 'done',
+        value: true,
+      });
+
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        10,
+        expect.objectContaining({
+          description: 'important notes',
+          priority: 3,
+          done: true,
+        }),
+      );
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        11,
+        expect.objectContaining({
+          description: 'important notes',
+          priority: 3,
+          done: true,
+        }),
+      );
     });
 
     it('should handle string "false" value for done field in bulk update', async () => {
       const taskIds = [1, 2];
       mockClient.tasks.getTask.mockImplementation((id: number) =>
-        Promise.resolve({ ...mockTask, id, done: false }),
+        Promise.resolve({ ...mockTask, id, done: true }),
       );
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
-      
+
       const result = await callTool('bulk-update', {
         taskIds,
         field: 'done',
-        value: 'false' as any, // String "false" should be converted to boolean false
+        value: 'false' as any,
       });
-      
-      // Should call bulk update API with boolean false (not string "false")
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'done',
-        value: false, // Converted from string "false" to boolean false
-      });
-      
+
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ done: false }),
+      );
+
       const markdown = result.content[0].text;
       const parsed = parseMarkdown(markdown);
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
-      expect(markdown).toContain('update-task');
       expect(markdown).toContain('Successfully updated 2 tasks');
     });
 
@@ -1614,10 +1647,6 @@ describe('Tasks Tool', () => {
     });
 
     it('should handle API errors in bulk update', async () => {
-      // Mock bulk API to fail
-      mockClient.tasks.bulkUpdateTasks.mockRejectedValue(new Error('Bulk API failed'));
-
-      // Mock individual updates to also fail
       mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1', project_id: 1 });
       mockClient.tasks.updateTask.mockRejectedValue(new Error('Bulk update failed'));
 
@@ -1631,10 +1660,6 @@ describe('Tasks Tool', () => {
     });
 
     it('should handle non-Error API errors in bulk update', async () => {
-      // Mock bulk API to fail
-      mockClient.tasks.bulkUpdateTasks.mockRejectedValue(new Error('Bulk API failed'));
-
-      // Mock individual updates to also fail with string error
       mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1', project_id: 1 });
       mockClient.tasks.updateTask.mockRejectedValue('String error');
 
@@ -1648,239 +1673,44 @@ describe('Tasks Tool', () => {
     });
 
     it('should handle string boolean values in bulk update', async () => {
-      const mockTasks = [
-        { id: 1, title: 'Task 1', done: false },
-        { id: 2, title: 'Task 2', done: false },
-      ];
-
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...mockTasks[0], done: true })
-        .mockResolvedValueOnce({ ...mockTasks[1], done: true });
+      mockClient.tasks.getTask.mockImplementation((id: number) =>
+        Promise.resolve({ ...mockTask, id, done: false }),
+      );
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
         field: 'done',
-        value: 'true', // String instead of boolean
+        value: 'true',
       });
 
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'done',
-        value: true, // Should be converted to boolean
-      });
-      expect(result.content[0].text).toContain('"success": true');
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ done: true }),
+      );
+      expect(result.content[0].text).toContain('Successfully updated 2 tasks');
     });
 
     it('should handle string numeric values in bulk update', async () => {
-      const mockTasks = [
-        { id: 1, title: 'Task 1', priority: 0 },
-        { id: 2, title: 'Task 2', priority: 0 },
-      ];
-
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...mockTasks[0], priority: 5 })
-        .mockResolvedValueOnce({ ...mockTasks[1], priority: 5 });
+      mockClient.tasks.getTask.mockImplementation((id: number) =>
+        Promise.resolve({ ...mockTask, id, priority: 0 }),
+      );
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
         field: 'priority',
-        value: '5', // String instead of number
+        value: '5',
       });
 
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'priority',
-        value: 5, // Should be converted to number
-      });
-      expect(result.content[0].text).toContain('"success": true');
-    });
-
-    it('should handle bulk update API returning Message object instead of Task array', async () => {
-      // Mock bulk update API to return Message object (instead of Task[] array)
-      const messageResponse = { message: 'Tasks successfully updated' };
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue(messageResponse as any);
-
-      // Mock getTask calls to fetch updated tasks
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ id: 1, title: 'Task 1', priority: 5, done: false })
-        .mockResolvedValueOnce({ id: 2, title: 'Task 2', priority: 5, done: false });
-
-      const result = await callTool('bulk-update', {
-        taskIds: [1, 2],
-        field: 'priority',
-        value: 5,
-      });
-
-      // Verify bulk update API was called
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'priority',
-        value: 5,
-      });
-
-      // New implementation may handle task fetching differently
-
-      // Verify successful response
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
-      expect(tasksData.tasks).toHaveLength(2);
-      expect(tasksData.tasks[0].priority).toBe(5);
-      expect(tasksData.tasks[1].priority).toBe(5);
-    });
-
-    it('should detect and fix bulk update failures when API returns unchanged values', async () => {
-      // Mock initial tasks with different priorities
-      const task1 = { ...mockTask, id: 371, title: 'Task 371', priority: 3 };
-      const task2 = { ...mockTask, id: 372, title: 'Task 372', priority: 4 };
-
-      // Mock bulk update API to return tasks with UNCHANGED values (simulating the bug)
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue([task1, task2]);
-
-      // Mock getTask for fetching current task state (used by fallback)
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce(task1)  // First task for fallback update
-        .mockResolvedValueOnce(task2); // Second task for fallback update
-
-      // Mock updateTask for the fallback individual updates
-      mockClient.tasks.updateTask
-        .mockResolvedValueOnce({ ...task1, priority: 5 })
-        .mockResolvedValueOnce({ ...task2, priority: 5 });
-
-      // Mock final getTask calls to return updated values
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...task1, priority: 5 })
-        .mockResolvedValueOnce({ ...task2, priority: 5 });
-
-      const result = await callTool('bulk-update', {
-        taskIds: [371, 372],
-        field: 'priority',
-        value: 5,
-      });
-
-      // Verify bulk update API was called first
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [371, 372],
-        field: 'priority',
-        value: 5,
-      });
-
-      // Verify fallback to individual updates was triggered
-      expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(2);
-      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(371, expect.objectContaining({ priority: 5 }));
-      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(372, expect.objectContaining({ priority: 5 }));
-
-      // Parse response and verify tasks have been updated via fallback
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
-      expect(tasksData.tasks).toHaveLength(2);
-      
-      // Verify that the returned tasks now show the UPDATED priority values
-      const updatedTask1 = tasksData.tasks.find(t => t.id === 371);
-      const updatedTask2 = tasksData.tasks.find(t => t.id === 372);
-      
-      expect(updatedTask1.priority).toBe(5); // Updated to 5
-      expect(updatedTask2.priority).toBe(5); // Updated to 5
-    });
-
-    it('should detect bulk update failures for done field', async () => {
-      const task1 = { ...mockTask, id: 1, done: false };
-      const task2 = { ...mockTask, id: 2, done: false };
-
-      // Mock bulk update API returns unchanged values
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue([task1, task2]);
-
-      // Mock fallback
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce(task1)
-        .mockResolvedValueOnce(task2);
-      mockClient.tasks.updateTask
-        .mockResolvedValueOnce({ ...task1, done: true })
-        .mockResolvedValueOnce({ ...task2, done: true });
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...task1, done: true })
-        .mockResolvedValueOnce({ ...task2, done: true });
-
-      const result = await callTool('bulk-update', {
-        taskIds: [1, 2],
-        field: 'done',
-        value: true,
-      });
-
-      expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(2);
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      expect(tasksData.tasks.every(t => t.done === true)).toBe(true);
-    });
-
-    it('should detect bulk update failures for due_date field', async () => {
-      const task1 = { ...mockTask, id: 1, due_date: '2024-01-01T00:00:00Z' };
-      const task2 = { ...mockTask, id: 2, due_date: '2024-01-02T00:00:00Z' };
-      const newDueDate = '2024-12-31T23:59:59Z';
-
-      // Mock bulk update API returns unchanged values
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue([task1, task2]);
-
-      // Mock fallback
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce(task1)
-        .mockResolvedValueOnce(task2);
-      mockClient.tasks.updateTask
-        .mockResolvedValueOnce({ ...task1, due_date: newDueDate })
-        .mockResolvedValueOnce({ ...task2, due_date: newDueDate });
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...task1, due_date: newDueDate })
-        .mockResolvedValueOnce({ ...task2, due_date: newDueDate });
-
-      const result = await callTool('bulk-update', {
-        taskIds: [1, 2],
-        field: 'due_date',
-        value: newDueDate,
-      });
-
-      expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(2);
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      expect(tasksData.tasks.every(t => t.due_date === newDueDate)).toBe(true);
-    });
-
-    it('should detect bulk update failures for project_id field', async () => {
-      const task1 = { ...mockTask, id: 1, project_id: 1 };
-      const task2 = { ...mockTask, id: 2, project_id: 1 };
-
-      // Mock bulk update API returns unchanged values
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue([task1, task2]);
-
-      // Mock fallback
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce(task1)
-        .mockResolvedValueOnce(task2);
-      mockClient.tasks.updateTask
-        .mockResolvedValueOnce({ ...task1, project_id: 5 })
-        .mockResolvedValueOnce({ ...task2, project_id: 5 });
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...task1, project_id: 5 })
-        .mockResolvedValueOnce({ ...task2, project_id: 5 });
-
-      const result = await callTool('bulk-update', {
-        taskIds: [1, 2],
-        field: 'project_id',
-        value: 5,
-      });
-
-      expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(2);
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      expect(tasksData.tasks.every(t => t.project_id === 5)).toBe(true);
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ priority: 5 }),
+      );
+      expect(result.content[0].text).toContain('Successfully updated 2 tasks');
     });
 
     it('should validate recurring fields in bulk update', async () => {
-      // Test repeat_after validation
       await expect(
         callTool('bulk-update', {
           taskIds: [1, 2],
@@ -1889,7 +1719,6 @@ describe('Tasks Tool', () => {
         }),
       ).rejects.toThrow('repeat_after must be a non-negative number');
 
-      // Test repeat_mode validation
       await expect(
         callTool('bulk-update', {
           taskIds: [1, 2],
@@ -1900,13 +1729,9 @@ describe('Tasks Tool', () => {
     });
 
     it('should bulk update recurring settings', async () => {
-      const updatedTask1 = { ...mockTask, id: 1, repeat_after: 7, repeat_mode: 'week' };
-      const updatedTask2 = { ...mockTask, id: 2, repeat_after: 7, repeat_mode: 'week' };
-
       mockClient.tasks.getTask.mockImplementation((id: number) =>
-        Promise.resolve({ ...mockTask, id, repeat_after: 7 }),
+        Promise.resolve({ ...mockTask, id, repeat_after: 0 }),
       );
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
@@ -1914,14 +1739,15 @@ describe('Tasks Tool', () => {
         value: 7,
       });
 
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'repeat_after',
-        value: 7,
-      });
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ repeat_after: 7 }),
+      );
 
       const markdown = result.content[0].text;
       const parsed = parseMarkdown(markdown);
+      expect(parsed.getAorpStatus().type).toBe('success');
     });
 
     it('should validate max tasks limit', async () => {
@@ -1982,11 +1808,7 @@ describe('Tasks Tool', () => {
       ).rejects.toThrow('labels ID must be a positive integer');
     });
 
-    it('should fall back to individual updates when bulk API fails', async () => {
-      // Mock bulk API to fail
-      mockClient.tasks.bulkUpdateTasks.mockRejectedValue(new Error('Bulk API not available'));
-
-      // Mock individual updates
+    it('should update via individual merge when setting done', async () => {
       mockClient.tasks.getTask.mockImplementation((id: number) =>
         Promise.resolve({ ...mockTask, id }),
       );
@@ -2000,10 +1822,7 @@ describe('Tasks Tool', () => {
         value: true,
       });
 
-      // Should have tried bulk API first
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledTimes(1);
-
-      // Should fall back to individual updates
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
       expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(2);
       expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
         1,
@@ -2021,41 +1840,8 @@ describe('Tasks Tool', () => {
       expect(markdown).toContain('Successfully updated 2 tasks');
     });
 
-    it('should handle partial fetch failures after bulk update', async () => {
-      // Mock bulk update API to fail so we use fallback
-      mockClient.tasks.bulkUpdateTasks.mockRejectedValue(new Error('Bulk API failed'));
-
-      // Mock individual updates to succeed
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...mockTask, id: 1 })
-        .mockResolvedValueOnce({ ...mockTask, id: 2 })
-        .mockResolvedValueOnce({ ...mockTask, id: 3 });
-
-      mockClient.tasks.updateTask.mockResolvedValue({ ...mockTask, done: true });
-
-      // Mock post-update fetches - one fails
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...mockTask, id: 1, done: true })
-        .mockRejectedValueOnce(new Error('Task not found'))
-        .mockResolvedValueOnce({ ...mockTask, id: 3, done: true });
-
-      const result = await callTool('bulk-update', {
-        taskIds: [1, 2, 3],
-        field: 'done',
-        value: true,
-      });
-
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
-      expect(markdown).toContain('Successfully updated 3 tasks');
-      expect(tasksData.tasks).toHaveLength(3);
-    });
-
     it('should handle bulk update for assignees field', async () => {
       mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, assignees: [] });
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
@@ -2068,16 +1854,12 @@ describe('Tasks Tool', () => {
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('Successfully updated 2 tasks');
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'assignees',
-        value: [1, 2],
-      });
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalled();
     });
 
     it('should handle bulk update for labels field', async () => {
       mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, labels: [] });
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
@@ -2090,16 +1872,12 @@ describe('Tasks Tool', () => {
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('Successfully updated 2 tasks');
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'labels',
-        value: [1, 2, 3],
-      });
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(2);
     });
 
     it('should handle bulk update for due_date field', async () => {
-      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, due_date: '2024-12-31T23:59:59Z' });
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
+      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, due_date: '2024-01-01T00:00:00Z' });
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
@@ -2112,16 +1890,15 @@ describe('Tasks Tool', () => {
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('Successfully updated 2 tasks');
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'due_date',
-        value: '2024-12-31T23:59:59Z',
-      });
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ due_date: '2024-12-31T23:59:59Z' }),
+      );
     });
 
     it('should handle bulk update for project_id field', async () => {
-      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, project_id: 5 });
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
+      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, project_id: 1 });
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
@@ -2134,16 +1911,15 @@ describe('Tasks Tool', () => {
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('Successfully updated 2 tasks');
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'project_id',
-        value: 5,
-      });
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ project_id: 5 }),
+      );
     });
 
     it('should handle bulk update for repeat_mode field', async () => {
-      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, repeat_mode: 1 });
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
+      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, repeat_mode: 0 });
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
@@ -2156,11 +1932,14 @@ describe('Tasks Tool', () => {
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('Successfully updated 2 tasks');
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ repeat_mode: 1 }),
+      );
     });
 
     it('should handle bulk update for repeat_after field', async () => {
-      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, repeat_after: 86400 });
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
+      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, repeat_after: 0 });
 
       const result = await callTool('bulk-update', {
         taskIds: [1, 2],
@@ -2173,110 +1952,18 @@ describe('Tasks Tool', () => {
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('Successfully updated 2 tasks');
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: [1, 2],
-        field: 'repeat_after',
-        value: 86400,
-      });
-    });
-
-    it('should handle non-auth errors in assignee updates during bulk-update', async () => {
-      // Mock bulk API success
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue({ message: 'Tasks updated successfully' });
-
-      // Mock assignee operations to fail
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...mockTask, id: 1, assignees: [] })
-        .mockResolvedValueOnce({ ...mockTask, id: 1, assignees: [] });
-      mockClient.tasks.bulkAssignUsersToTask.mockRejectedValue(new Error('Invalid user ID'));
-
-      const result = await callTool('bulk-update', {
-        taskIds: [1],
-        field: 'assignees',
-        value: [999],
-      });
-
-      // The bulk update should succeed but warn about assignee failures
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
-      expect(markdown).toContain('Successfully updated 1 tasks');
-    });
-
-    it('should handle assignee removal failures during bulk update', async () => {
-      // Mock bulk API to fail (which triggers fallback)
-      mockClient.tasks.bulkUpdateTasks.mockRejectedValue(new Error('Bulk API not supported'));
-
-      // Mock task with existing assignees
-      const taskWithAssignees = {
-        ...mockTask,
-        id: 1,
-        assignees: [{ id: 1, username: 'user1' }],
-      };
-      
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce(taskWithAssignees) // For fetch at start
-        .mockResolvedValueOnce(taskWithAssignees) // For assignee diff calculation
-        .mockResolvedValueOnce({ ...taskWithAssignees, assignees: [] }); // For final fetch
-      
-      mockClient.tasks.updateTask.mockResolvedValue(taskWithAssignees);
-      
-      // Mock removeUserFromTask to fail
-      mockClient.tasks.removeUserFromTask.mockRejectedValue(new Error('Failed to remove user'));
-
-      await expect(callTool('bulk-update', {
-        taskIds: [1],
-        field: 'assignees',
-        value: [],
-      })).rejects.toThrow('Bulk update failed. Could not update any tasks');
-
-      expect(mockClient.tasks.removeUserFromTask).toHaveBeenCalledWith(1, 1);
-    });
-
-    it('should handle partial success in bulk update', async () => {
-      // Mock bulk API to fail (which triggers fallback)
-      mockClient.tasks.bulkUpdateTasks.mockRejectedValue(new Error('Bulk API not supported'));
-      
-      // Mock initial task fetches
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...mockTask, id: 1 }) // initial fetch for task 1
-        .mockResolvedValueOnce({ ...mockTask, id: 2 }); // initial fetch for task 2
-      
-      // Mock update to succeed for both tasks
-      mockClient.tasks.updateTask
-        .mockResolvedValueOnce({ ...mockTask, id: 1, priority: 5 })
-        .mockResolvedValueOnce({ ...mockTask, id: 2, priority: 5 });
-      
-      // Mock the final fetch - succeed for task 1, fail for task 2
-      mockClient.tasks.getTask
-        .mockResolvedValueOnce({ ...mockTask, id: 1, priority: 5 })
-        .mockRejectedValueOnce(new Error('Task not found'));
-
-      const result = await callTool('bulk-update', {
-        taskIds: [1, 2],
-        field: 'priority',
-        value: 5,
-      });
-
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
-      expect(markdown).toContain('Successfully updated 2 tasks');
-      // New batch processing system doesn't have the same fetch failure behavior
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ repeat_after: 86400 }),
+      );
     });
 
     it('should handle generic errors in bulk update', async () => {
-      // Mock bulk API to succeed initially
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue([]);
-      
-      // Mock getTask to throw TypeError when fetching results
       mockClient.tasks.getTask.mockImplementation(() => {
         throw new TypeError('Cannot read property of undefined');
       });
 
-      // When all individual updates fail in the fallback, it should report failure
       await expect(
         callTool('bulk-update', {
           taskIds: [1, 2],

--- a/tests/tools/tasks/bulk-operations.test.ts
+++ b/tests/tools/tasks/bulk-operations.test.ts
@@ -132,128 +132,152 @@ describe('Bulk operations', () => {
 
     describe('Type coercion', () => {
       it('should convert string "true" to boolean for done field', async () => {
-        const mockTasks = [{ id: 1, done: true }, { id: 2, done: true }];
-        mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
+        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'T', done: false });
+        mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'T', done: true });
 
-        await bulkUpdateTasks({ taskIds: [1, 2], field: 'done', value: 'true' });
+        await bulkUpdateTasks({ taskIds: [1], field: 'done', value: 'true' });
 
-        expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-          task_ids: [1, 2],
-          field: 'done',
-          value: true,
-        });
+        expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({ done: true }),
+        );
       });
 
       it('should convert string "false" to boolean for done field', async () => {
-        const mockTasks = [{ id: 1, done: false }, { id: 2, done: false }];
-        mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
+        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'T', done: true });
+        mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'T', done: false });
 
-        await bulkUpdateTasks({ taskIds: [1, 2], field: 'done', value: 'false' });
+        await bulkUpdateTasks({ taskIds: [1], field: 'done', value: 'false' });
 
-        expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-          task_ids: [1, 2],
-          field: 'done',
-          value: false,
-        });
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({ done: false }),
+        );
       });
 
       it('should convert string numbers to numbers for priority field', async () => {
-        const mockTasks = [{ id: 1, priority: 3 }, { id: 2, priority: 3 }];
-        mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
+        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'T', priority: 0 });
+        mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'T', priority: 3 });
 
-        await bulkUpdateTasks({ taskIds: [1, 2], field: 'priority', value: '3' });
+        await bulkUpdateTasks({ taskIds: [1], field: 'priority', value: '3' });
 
-        expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-          task_ids: [1, 2],
-          field: 'priority',
-          value: 3,
-        });
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({ priority: 3 }),
+        );
       });
     });
 
-    describe('Bulk API success path', () => {
-      it('should handle successful bulk update with array response', async () => {
-        const mockTasks = [
-          { id: 1, title: 'Task 1', done: true },
-          { id: 2, title: 'Task 2', done: true },
-        ];
-        mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
-
-        const result = await bulkUpdateTasks({ taskIds: [1, 2], field: 'done', value: true });
-
-        expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-          task_ids: [1, 2],
-          field: 'done',
-          value: true,
-        });
-
-        const markdown = result.content[0].text;
-        const parsed = parseMarkdown(markdown);
-        expect(markdown).toContain("## ✅ Success");
-        expect(markdown).toContain('Successfully updated 2 tasks');
-        expect(markdown).toContain('**Operation:** update-task');
-        expect(markdown).toContain('**count:** 2');
-      });
-
-      it('should handle successful bulk update with message response', async () => {
-        const mockMessage = { message: 'Tasks updated successfully' };
-        const mockTasks = [
-          { id: 1, title: 'Task 1', done: true },
-          { id: 2, title: 'Task 2', done: true },
-        ];
-
-        mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockMessage);
-        mockClient.tasks.getTask.mockResolvedValueOnce(mockTasks[0]).mockResolvedValueOnce(mockTasks[1]);
-
-        const result = await bulkUpdateTasks({ taskIds: [1, 2], field: 'done', value: true });
-
-        expect(mockClient.tasks.getTask).toHaveBeenCalledTimes(2);
-
-        const markdown = result.content[0].text;
-        const parsed = parseMarkdown(markdown);
-        expect(markdown).toContain("## ✅ Success");
-        expect(markdown).toContain('**count:** 2');
-      });
-
-      it('should handle repeat_mode conversion', async () => {
-        const mockTasks = [{ id: 1, repeat_mode: 1 }];
-        mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
-
-        await bulkUpdateTasks({ taskIds: [1], field: 'repeat_mode', value: 'month' });
-
-        expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-          task_ids: [1],
-          field: 'repeat_mode',
-          value: 1,
-        });
-      });
-    });
-
-    describe('Bulk API failure and fallback', () => {
-      it('should fallback to individual updates when bulk API fails', async () => {
-        const bulkError = new Error('Bulk API not available');
-        const mockTask = { id: 1, title: 'Task 1', done: true };
-
-        mockClient.tasks.bulkUpdateTasks.mockRejectedValue(bulkError);
-        mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1', done: false });
-        mockClient.tasks.updateTask.mockResolvedValue(mockTask);
+    describe('Per-task merge updates (avoids native bulk wipe)', () => {
+      it('should update via get+merge+update and never call native bulk API', async () => {
+        const current = {
+          id: 1,
+          title: 'Task 1',
+          project_id: 1,
+          description: 'keep me',
+          priority: 4,
+          done: false,
+        };
+        const updated = { ...current, done: true };
+        mockClient.tasks.getTask.mockResolvedValue(current);
+        mockClient.tasks.updateTask.mockResolvedValue(updated);
 
         const result = await bulkUpdateTasks({ taskIds: [1], field: 'done', value: true });
 
-        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(1, expect.objectContaining({
-          done: true,
-        }));
+        expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+        expect(mockClient.tasks.getTask).toHaveBeenCalledWith(1);
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({
+            title: 'Task 1',
+            description: 'keep me',
+            priority: 4,
+            done: true,
+          }),
+        );
 
         const markdown = result.content[0].text;
-        const parsed = parseMarkdown(markdown);
-        expect(markdown).toContain("## ✅ Success");
+        expect(markdown).toContain('## ✅ Success');
+        expect(markdown).toContain('Successfully updated 1 tasks');
+        expect(markdown).toContain('**Operation:** update-task');
+        expect(markdown).toContain('**count:** 1');
       });
 
-      it('should handle assignees field in fallback mode', async () => {
-        const bulkError = new Error('Bulk API failed');
+      it('should preserve description and priority when marking done (issue #46)', async () => {
+        const tasks = [
+          {
+            id: 10,
+            title: 'A',
+            project_id: 1,
+            description: 'notes for A',
+            priority: 3,
+            done: false,
+          },
+          {
+            id: 11,
+            title: 'B',
+            project_id: 1,
+            description: 'notes for B',
+            priority: 5,
+            done: false,
+          },
+        ];
+        mockClient.tasks.getTask.mockImplementation(async (id: number) => {
+          const task = tasks.find((t) => t.id === id);
+          if (!task) throw new Error(`missing ${id}`);
+          return { ...task };
+        });
+        mockClient.tasks.updateTask.mockImplementation(async (_id: number, payload: Record<string, unknown>) => payload);
+
+        await bulkUpdateTasks({ taskIds: [10, 11], field: 'done', value: true });
+
+        expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(2);
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+          10,
+          expect.objectContaining({
+            description: 'notes for A',
+            priority: 3,
+            done: true,
+          }),
+        );
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+          11,
+          expect.objectContaining({
+            description: 'notes for B',
+            priority: 5,
+            done: true,
+          }),
+        );
+      });
+
+      it('should handle repeat_mode conversion on merge path', async () => {
+        mockClient.tasks.getTask.mockResolvedValue({
+          id: 1,
+          title: 'T',
+          project_id: 1,
+          repeat_mode: 0,
+        });
+        mockClient.tasks.updateTask.mockResolvedValue({
+          id: 1,
+          title: 'T',
+          project_id: 1,
+          repeat_mode: 1,
+        });
+
+        await bulkUpdateTasks({ taskIds: [1], field: 'repeat_mode', value: 'month' });
+
+        expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+        expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({ repeat_mode: 1 }),
+        );
+      });
+
+      it('should handle assignees field', async () => {
         const mockTask = { id: 1, title: 'Task 1', assignees: [] };
 
-        mockClient.tasks.bulkUpdateTasks.mockRejectedValue(bulkError);
         mockClient.tasks.getTask
           .mockResolvedValueOnce({ id: 1, title: 'Task 1', assignees: [] })
           .mockResolvedValueOnce({ id: 1, title: 'Task 1', assignees: [{ id: 1 }] })
@@ -268,55 +292,39 @@ describe('Bulk operations', () => {
         });
 
         const markdown = result.content[0].text;
-        const parsed = parseMarkdown(markdown);
-        expect(markdown).toContain("## ✅ Success");
+        expect(markdown).toContain('## ✅ Success');
       });
 
       it('should handle authentication errors in assignee operations', async () => {
-        const bulkError = new Error('Bulk API failed');
         const authError = new Error('Authentication failed');
-        
-        mockClient.tasks.bulkUpdateTasks.mockRejectedValue(bulkError);
+
         mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1', assignees: [] });
         mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'Task 1' });
         (withRetry as jest.Mock).mockRejectedValue(authError);
         (isAuthenticationError as jest.Mock).mockReturnValue(true);
 
         await expect(bulkUpdateTasks({ taskIds: [1], field: 'assignees', value: [1] })).rejects.toThrow(
-          'Assignee operations may have authentication issues'
+          'Assignee operations may have authentication issues',
         );
-      });
-
-      it('should handle bulk update that reports success but didnt actually update', async () => {
-        const mockTask = { id: 1, title: 'Task 1', project_id: 1, done: false }; // Value not updated
-        mockClient.tasks.bulkUpdateTasks.mockResolvedValue([mockTask]);
-
-        // This should trigger fallback due to value mismatch
-        const result = await bulkUpdateTasks({ taskIds: [1], field: 'done', value: true });
-
-        // Should have fallen back to individual update
-        expect(mockClient.tasks.updateTask).toHaveBeenCalled();
       });
     });
 
     describe('Error handling', () => {
       it('should preserve MCPError instances', async () => {
         const mcpError = new MCPError(ErrorCode.NOT_FOUND, 'Task not found');
-        mockClient.tasks.bulkUpdateTasks.mockRejectedValue(mcpError);
         mockClient.tasks.getTask.mockRejectedValue(mcpError);
 
         await expect(bulkUpdateTasks({ taskIds: [1], field: 'done', value: true })).rejects.toThrow(
-          'Bulk update failed. Could not update any tasks. Failed IDs: 1'
+          'Bulk update failed. Could not update any tasks. Failed IDs: 1',
         );
       });
 
       it('should handle unknown error types', async () => {
         const unknownError = { status: 'error' };
-        mockClient.tasks.bulkUpdateTasks.mockRejectedValue(unknownError);
         mockClient.tasks.getTask.mockRejectedValue(unknownError);
 
         await expect(bulkUpdateTasks({ taskIds: [1], field: 'done', value: true })).rejects.toThrow(
-          'Bulk update failed. Could not update any tasks. Failed IDs: 1'
+          'Bulk update failed. Could not update any tasks. Failed IDs: 1',
         );
       });
     });
@@ -650,17 +658,29 @@ describe('Bulk operations', () => {
   describe('Batch processing', () => {
     it('should process large numbers of tasks in batches', async () => {
       const taskIds = Array.from({ length: 25 }, (_, i) => i + 1);
-      const mockTasks = taskIds.map(id => ({ id, title: `Task ${id}`, done: true }));
 
-      mockClient.tasks.bulkUpdateTasks.mockResolvedValue(mockTasks);
+      mockClient.tasks.getTask.mockImplementation(async (id: number) => ({
+        id,
+        title: `Task ${id}`,
+        project_id: 1,
+        description: `desc ${id}`,
+        priority: 2,
+        done: false,
+      }));
+      mockClient.tasks.updateTask.mockImplementation(async (_id: number, payload: Record<string, unknown>) => payload);
 
       const result = await bulkUpdateTasks({ taskIds, field: 'done', value: true });
 
-      expect(mockClient.tasks.bulkUpdateTasks).toHaveBeenCalledWith({
-        task_ids: taskIds,
-        field: 'done',
-        value: true,
-      });
+      expect(mockClient.tasks.bulkUpdateTasks).not.toHaveBeenCalled();
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledTimes(25);
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          description: 'desc 1',
+          priority: 2,
+          done: true,
+        }),
+      );
 
       const markdown = result.content[0].text;
       expect(markdown).toContain('**count:** 25');


### PR DESCRIPTION
## Summary
- `bulk-update` no longer calls Vikunja's native `bulkUpdateTasks` API, which was wiping fields not in the request (description, priority, etc.) because Vikunja treats task updates as a full replace.
- Always uses the existing safe path: fetch each task → merge the one changed field → write back — same idea as single-task `update`.
- Adds a regression test that `done=true` keeps description/priority (covers #46).

## Trade-off
This is deliberately a safety workaround, not a Vikunja API change. Bulk updates are slower (O(n) get+update) but no longer destructive.

## Test plan
- [x] `npx jest tests/tools/tasks/bulk-operations.test.ts`
- [x] `npx jest tests/tools/tasks.test.ts -t 'bulk-update'`
- [x] `npm run build`
- [ ] After merge: pin a release in consumers that currently use `npx -y` so the fix is what agents actually run

Fixes #46