### PR TITLE
fix(projects): preserve fields on partial update (fixes #44, #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1068,8 +1068,9 @@ This standardized format ensures:
     - Optional: description, parentProjectId, isArchived, hexColor (format: #RRGGBB)
     - Validates parent project hierarchy depth (max 10 levels)
   - `update` - Update existing project
-    - Supports partial updates
+    - Supports partial updates (fetches current project and merges; omitted fields are preserved)
     - Can update all project fields including hexColor (format: #RRGGBB)
+    - Omitting `parentProjectId` leaves the current parent unchanged (use `move` to reparent or detach)
     - Validates parent project hierarchy depth when changing parent
   - `delete` - Delete a project by ID
   - `archive` - Archive a project

--- a/src/tools/projects/crud.ts
+++ b/src/tools/projects/crud.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Project, ProjectListParams } from 'node-vikunja';
-import { MCPError, ErrorCode, type CreateProjectRequest, type UpdateProjectRequest } from '../../types';
+import { MCPError, ErrorCode, type CreateProjectRequest } from '../../types';
 import { getClientFromContext } from '../../client';
 import { transformApiError, handleStatusCodeError } from '../../utils/error-handler';
 import { validateId, validateHexColor, validateProjectData, calculateProjectDepth } from './validation';
@@ -96,6 +96,31 @@ export interface ArchiveProjectArgs {
   verbosity?: string;
   useOptimizedFormat?: boolean;
   useAorp?: boolean;
+}
+
+/**
+ * Builds a project update payload by merging current project state with
+ * requested field changes. Vikunja's update endpoint replaces the whole
+ * model, so omitted fields would otherwise be cleared (e.g. parent_project_id → 0).
+ */
+export function buildProjectUpdatePayload(
+  currentProject: Project,
+  updates: {
+    title?: string;
+    description?: string;
+    parentProjectId?: number;
+    isArchived?: boolean;
+    hexColor?: string;
+  }
+): Project {
+  return {
+    ...currentProject,
+    ...(updates.title !== undefined && { title: updates.title.trim() }),
+    ...(updates.description !== undefined && { description: updates.description.trim() }),
+    ...(updates.parentProjectId !== undefined && { parent_project_id: updates.parentProjectId }),
+    ...(updates.isArchived !== undefined && { is_archived: updates.isArchived }),
+    ...(updates.hexColor !== undefined && { hex_color: updates.hexColor.toLowerCase() }),
+  };
 }
 
 /**
@@ -410,26 +435,26 @@ export async function updateProject(
       }
     }
 
-    // Prepare update data
-    const updateData: UpdateProjectRequest = {};
+    // Vikunja project update is a full-model replace. Merge with the current
+    // project so omitted fields (especially parent_project_id) are preserved.
+    // Detaching from a parent requires an explicit parentProjectId change
+    // (or using the move subcommand). See issue #45.
+    const fieldUpdates: {
+      title?: string;
+      description?: string;
+      parentProjectId?: number;
+      isArchived?: boolean;
+      hexColor?: string;
+    } = {};
+    if (title !== undefined) fieldUpdates.title = title;
+    if (description !== undefined) fieldUpdates.description = description;
+    if (parentProjectId !== undefined) fieldUpdates.parentProjectId = parentProjectId;
+    if (isArchived !== undefined) fieldUpdates.isArchived = isArchived;
+    if (hexColor !== undefined) fieldUpdates.hexColor = hexColor;
 
-    if (title !== undefined) {
-      updateData.title = title.trim();
-    }
-    if (description !== undefined) {
-      updateData.description = description.trim();
-    }
-    if (parentProjectId !== undefined) {
-      updateData.parent_project_id = parentProjectId;
-    }
-    if (isArchived !== undefined) {
-      updateData.is_archived = isArchived;
-    }
-    if (hexColor !== undefined) {
-      updateData.hex_color = hexColor.toLowerCase();
-    }
+    const updateData = buildProjectUpdatePayload(currentProject, fieldUpdates);
 
-    const updatedProject = await client.projects.updateProject(id, updateData as Project);
+    const updatedProject = await client.projects.updateProject(id, updateData);
 
     const result = createProjectResponse(
       'update_project',
@@ -549,11 +574,11 @@ export async function archiveProject(
       };
     }
 
-    // Archive the project
-    const project = await client.projects.updateProject(id, {
-      title: currentProject.title,
-      is_archived: true
-    } as Project);
+    // Archive the project (merge so parent/other fields are not wiped)
+    const project = await client.projects.updateProject(
+      id,
+      buildProjectUpdatePayload(currentProject, { isArchived: true })
+    );
 
     const result = createProjectResponse(
       'archive_project',
@@ -624,11 +649,11 @@ export async function unarchiveProject(
       };
     }
 
-    // Unarchive the project
-    const project = await client.projects.updateProject(id, {
-      title: currentProject.title,
-      is_archived: false
-    } as Project);
+    // Unarchive the project (merge so parent/other fields are not wiped)
+    const project = await client.projects.updateProject(
+      id,
+      buildProjectUpdatePayload(currentProject, { isArchived: false })
+    );
 
     const result = createProjectResponse(
       'unarchive_project',

--- a/tests/tools/archive-logic.test.ts
+++ b/tests/tools/archive-logic.test.ts
@@ -79,7 +79,7 @@ describe('Archive/Unarchive Logic', () => {
 
       expect(mockClient.projects.getProject).toHaveBeenCalledWith(1);
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
-        title: 'Test Project',
+        ...mockProject,
         is_archived: true
       });
 
@@ -113,7 +113,7 @@ describe('Archive/Unarchive Logic', () => {
 
       expect(mockClient.projects.getProject).toHaveBeenCalledWith(1);
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
-        title: 'Test Project',
+        ...archivedProject,
         is_archived: false
       });
 

--- a/tests/tools/projects-mock-fix.test.ts
+++ b/tests/tools/projects-mock-fix.test.ts
@@ -145,7 +145,7 @@ describe('Projects Tool Mock Fixes', () => {
 
       expect(mockClient.projects.getProject).toHaveBeenCalledWith(1);
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
-        title: 'Test Project',
+        ...mockProject,
         is_archived: true
       });
       expect(result.content[0].type).toBe('text');
@@ -168,7 +168,7 @@ describe('Projects Tool Mock Fixes', () => {
 
       expect(mockClient.projects.getProject).toHaveBeenCalledWith(1);
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
-        title: 'Test Project',
+        ...archivedProject,
         is_archived: false
       });
       expect(result.content[0].type).toBe('text');

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -482,6 +482,28 @@ describe('Projects Tool', () => {
       );
     });
 
+    it('should preserve existing title when title is omitted (issue #44)', async () => {
+      mockClient.projects.getProject.mockResolvedValue(mockProject);
+      mockClient.projects.updateProject.mockResolvedValue({
+        ...mockProject,
+        description: 'new description',
+      });
+
+      // Title intentionally omitted — Vikunja rejects updates without a title
+      await callTool('update', {
+        id: 1,
+        description: 'new description',
+      });
+
+      expect(mockClient.projects.updateProject).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          title: 'Test Project',
+          description: 'new description',
+        }),
+      );
+    });
+
     it('should still allow explicit parent reassignment on update', async () => {
       const childProject = {
         ...mockProject,

--- a/tests/tools/projects.test.ts
+++ b/tests/tools/projects.test.ts
@@ -441,6 +441,7 @@ describe('Projects Tool', () => {
       });
 
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
+        ...mockProject,
         title: 'Updated Title',
       });
       expect(result.content[0].type).toBe('text');
@@ -450,6 +451,63 @@ describe('Projects Tool', () => {
       expect(aorpStatus.type).toBe('success');
       expect(markdown).toContain('Project "Updated Title" updated successfully');
       expect(markdown).toMatch(/update[_\\]+project/);
+    });
+
+    it('should preserve parent_project_id when parentProjectId is omitted (issue #45)', async () => {
+      const childProject = {
+        ...mockProject,
+        id: 2,
+        title: 'Child Project',
+        parent_project_id: 1,
+      };
+      const updatedChild = { ...childProject, description: 'Updated description' };
+      mockClient.projects.getProject.mockResolvedValue(childProject);
+      mockClient.projects.getProjects.mockResolvedValue([mockProject, childProject]);
+      mockClient.projects.updateProject.mockResolvedValue(updatedChild);
+
+      await callTool('update', {
+        id: 2,
+        title: childProject.title,
+        description: 'Updated description',
+        // parentProjectId intentionally omitted
+      });
+
+      expect(mockClient.projects.updateProject).toHaveBeenCalledWith(
+        2,
+        expect.objectContaining({
+          description: 'Updated description',
+          parent_project_id: 1,
+          title: 'Child Project',
+        }),
+      );
+    });
+
+    it('should still allow explicit parent reassignment on update', async () => {
+      const childProject = {
+        ...mockProject,
+        id: 2,
+        title: 'Child Project',
+        parent_project_id: 1,
+      };
+      const newParent = { ...mockProject, id: 3, title: 'New Parent' };
+      mockClient.projects.getProject.mockResolvedValue(childProject);
+      mockClient.projects.getProjects.mockResolvedValue([mockProject, childProject, newParent]);
+      mockClient.projects.updateProject.mockResolvedValue({
+        ...childProject,
+        parent_project_id: 3,
+      });
+
+      await callTool('update', {
+        id: 2,
+        parentProjectId: 3,
+      });
+
+      expect(mockClient.projects.updateProject).toHaveBeenCalledWith(
+        2,
+        expect.objectContaining({
+          parent_project_id: 3,
+        }),
+      );
     });
 
     it('should require project ID', async () => {
@@ -469,6 +527,7 @@ describe('Projects Tool', () => {
     });
 
     it('should support updating all fields', async () => {
+      mockClient.projects.getProject.mockResolvedValue(mockProject);
       mockClient.projects.updateProject.mockResolvedValue(mockProject);
       mockClient.projects.getProjects.mockResolvedValue([
         mockProject,
@@ -485,6 +544,7 @@ describe('Projects Tool', () => {
       });
 
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
+        ...mockProject,
         title: 'New Title',
         description: 'New Description',
         parent_project_id: 2,
@@ -536,6 +596,7 @@ describe('Projects Tool', () => {
         for (const { input, expected } of validColors) {
           await callTool('update', { id: 1, hexColor: input });
           expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
+            ...mockProject,
             hex_color: expected,
           });
         }
@@ -621,7 +682,7 @@ describe('Projects Tool', () => {
 
       expect(mockClient.projects.getProject).toHaveBeenCalledWith(1);
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
-        title: 'Test Project',
+        ...mockProject,
         is_archived: true
       });
       expect(result.content[0].type).toBe('text');
@@ -698,7 +759,7 @@ describe('Projects Tool', () => {
 
       expect(mockClient.projects.getProject).toHaveBeenCalledWith(1);
       expect(mockClient.projects.updateProject).toHaveBeenCalledWith(1, {
-        title: 'Test Project',
+        ...archivedProject,
         is_archived: false
       });
       expect(result.content[0].type).toBe('text');


### PR DESCRIPTION
## Summary
- Vikunja's project update replaces the whole model, so omitting fields cleared or rejected them (parent → `0`, missing title → `Invalid Data`)
- Merge with the current project before update (same approach as task update), so omitted fields keep their existing values
- Apply the same merge for archive/unarchive so those paths do not wipe parent either

Fixes #44
Fixes #45

Reparent/detach remains explicit via `parentProjectId` or `move`.

## Test plan
- [x] Unit: update without `parentProjectId` keeps `parent_project_id` in the API payload (#45)
- [x] Unit: update without `title` still sends the current title (#44)
- [x] Unit: explicit `parentProjectId` still changes parent
- [x] Unit: archive/unarchive send full merged project
- [x] `npm run typecheck` and `npm run lint` pass
- [ ] Manual: child project → update description only → re-fetch still shows original parent and title