### PR TITLE
fix(tasks): honor projectId on update and labels on create (fixes #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ vikunja_tasks.update({
   priority: 5
 })
 
+// Move a task to another project (full-model merge; verified after update)
+vikunja_tasks.update({
+  id: 123,
+  projectId: 5
+})
+
 // Update recurring settings on an existing task
 vikunja_tasks.update({
   id: 123,
@@ -1016,8 +1022,9 @@ This standardized format ensures:
     - Validates date format (ISO 8601) and IDs
   - `get` - Get task details by ID
   - `update` - Update existing task
-    - Supports partial updates
+    - Supports partial updates (GET + merge before POST — Vikunja replaces the full model)
     - Can update title, description, dueDate, priority, done status
+    - Can move tasks between projects with `projectId` (verified after update)
     - Can update labels and assignees (uses efficient diff-based approach)
   - `delete` - Delete a task by ID
   - `assign` - Bulk assign users to tasks

--- a/src/tools/tasks/crud/TaskCreationService.ts
+++ b/src/tools/tasks/crud/TaskCreationService.ts
@@ -69,6 +69,11 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
       args.assignees.forEach((id) => validateId(id, 'assignee ID'));
     }
 
+    // Validate label IDs upfront
+    if (args.labels && args.labels.length > 0) {
+      args.labels.forEach((id) => validateId(id, 'label ID'));
+    }
+
     const client = await getClientFromContext();
 
     // Build the initial task object with sanitized values
@@ -94,6 +99,17 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
 
     // Create the base task
     const createdTask = await client.tasks.createTask(args.projectId, newTask);
+
+    // Labels/assignees require a task id — fail loudly instead of reporting success without them
+    const needsPostCreate =
+      (args.labels !== undefined && args.labels.length > 0) ||
+      (args.assignees !== undefined && args.assignees.length > 0);
+    if (needsPostCreate && !createdTask.id) {
+      throw new MCPError(
+        ErrorCode.API_ERROR,
+        'Task was created but Vikunja did not return a task id, so labels/assignees could not be applied',
+      );
+    }
 
     // Track creation state for potential rollback
     const creationState: CreationState = {
@@ -124,6 +140,25 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
     // Fetch the complete task with labels and assignees
     const completeTask = createdTask.id ? await client.tasks.getTask(createdTask.id) : createdTask;
 
+    // Verify labels actually stuck — avoid silent success when the API no-ops
+    if (args.labels && args.labels.length > 0) {
+      const attachedIds = new Set(
+        (completeTask.labels || [])
+          .map((label) => label.id)
+          .filter((id): id is number => typeof id === 'number'),
+      );
+      const missing = args.labels.filter((id) => !attachedIds.has(id));
+      if (missing.length > 0) {
+        await rollbackTaskCreation(
+          client,
+          creationState,
+          new Error(
+            `Labels were requested but not attached after create (missing label ids: ${missing.join(', ')})`,
+          ),
+        );
+      }
+    }
+
     const response = createTaskResponse(
       'create-task',
       'Task created successfully',
@@ -131,8 +166,8 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
       {
         timestamp: new Date().toISOString(),
         projectId: args.projectId,
-        labelsAdded: args.labels ? args.labels.length > 0 : false,
-        assigneesAdded: args.assignees ? args.assignees.length > 0 : false,
+        labelsAdded: creationState.labelsAdded,
+        assigneesAdded: creationState.assigneesAdded,
       },
       undefined, // verbosity (ignored - using standard AORP)
       undefined, // useOptimizedFormat (ignored - using standard AORP)
@@ -175,25 +210,28 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
 }
 
 /**
- * Adds labels to a task with retry logic for authentication errors
+ * Adds labels to a task.
+ * Uses addLabelToTask (same as apply-label) — updateTaskLabels can silently
+ * no-op on some Vikunja versions (GitHub #37).
+ *
+ * Intentionally does not use withRetry: that helper shares an "anonymous"
+ * circuit breaker across calls, so a later create would re-fire the first
+ * call's label set against the wrong task.
  */
 async function addLabelsToTask(client: VikunjaClient, taskId: number, labelIds: number[]): Promise<void> {
   try {
-    await withRetry(
-      () => client.tasks.updateTaskLabels(taskId, {
-        label_ids: labelIds,
-      }),
-      {
-        ...RETRY_CONFIG.AUTH_ERRORS,
-        shouldRetry: (error) => isAuthenticationError(error)
-      }
-    );
+    for (const labelId of labelIds) {
+      await client.tasks.addLabelToTask(taskId, {
+        task_id: taskId,
+        label_id: labelId,
+      });
+    }
   } catch (labelError) {
-    // Check if it's an auth error after retries
+    // Check if it's an auth error
     if (isAuthenticationError(labelError)) {
       throw new MCPError(
         ErrorCode.API_ERROR,
-        `${AUTH_ERROR_MESSAGES.LABEL_CREATE} (Retried ${RETRY_CONFIG.AUTH_ERRORS.maxRetries} times). Task ID: ${taskId}`,
+        `${AUTH_ERROR_MESSAGES.LABEL_CREATE} Task ID: ${taskId}`,
       );
     }
     throw labelError;

--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -21,6 +21,8 @@ export interface UpdateTaskArgs {
   dueDate?: string;
   priority?: number;
   done?: boolean;
+  /** Move the task to another project (merged into full-model update). */
+  projectId?: number;
   labels?: number[];
   assignees?: number[];
   repeatAfter?: number;
@@ -53,12 +55,17 @@ export async function updateTask(args: UpdateTaskArgs): Promise<{ content: Array
       validateDateString(args.dueDate, 'dueDate');
     }
 
+    // Validate project move target if provided
+    if (args.projectId !== undefined) {
+      validateId(args.projectId, 'projectId');
+    }
+
     const client = await getClientFromContext();
 
     // Analyze current state and track changes
     const updateState = await analyzeUpdateState(client, args.id, args);
 
-    // Build and apply the update
+    // Build and apply the update (full-model merge — Vikunja replaces the whole task)
     const updateData = buildUpdateData(updateState.currentTask, args);
     await client.tasks.updateTask(args.id, updateData);
 
@@ -74,6 +81,17 @@ export async function updateTask(args: UpdateTaskArgs): Promise<{ content: Array
 
     // Fetch the complete updated task
     const completeTask = await client.tasks.getTask(args.id);
+
+    // Verify project move actually stuck — Vikunja can report success while leaving
+    // the task in the old project (silent failure → data loss if the old project is deleted)
+    if (args.projectId !== undefined && completeTask.project_id !== args.projectId) {
+      throw new MCPError(
+        ErrorCode.API_ERROR,
+        `Failed to move task ${args.id} to project ${args.projectId}: ` +
+          `task remains in project ${completeTask.project_id ?? 'unknown'}. ` +
+          `The move was not applied by Vikunja.`,
+      );
+    }
 
     const response = createTaskResponse(
       'update-task',
@@ -135,6 +153,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   if (currentTask.due_date !== undefined) previousState.due_date = currentTask.due_date;
   if (currentTask.priority !== undefined) previousState.priority = currentTask.priority;
   if (currentTask.done !== undefined) previousState.done = currentTask.done;
+  if (currentTask.project_id !== undefined) previousState.project_id = currentTask.project_id;
   if (currentTask.repeat_after !== undefined) previousState.repeat_after = currentTask.repeat_after;
   if (currentTask.repeat_mode !== undefined) previousState.repeat_mode = currentTask.repeat_mode;
 
@@ -146,6 +165,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   if (args.dueDate !== undefined && args.dueDate !== currentTask.due_date) affectedFields.push('dueDate');
   if (args.priority !== undefined && args.priority !== currentTask.priority) affectedFields.push('priority');
   if (args.done !== undefined && args.done !== currentTask.done) affectedFields.push('done');
+  if (args.projectId !== undefined && args.projectId !== currentTask.project_id) affectedFields.push('projectId');
   if (args.repeatAfter !== undefined && args.repeatAfter !== currentTask.repeat_after) affectedFields.push('repeatAfter');
   if (args.repeatMode !== undefined && args.repeatMode !== currentTask.repeat_mode) affectedFields.push('repeatMode');
   if (args.labels !== undefined) affectedFields.push('labels');
@@ -171,6 +191,8 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
     ...(args.dueDate !== undefined && { due_date: args.dueDate }),
     ...(args.priority !== undefined && { priority: args.priority }),
     ...(args.done !== undefined && { done: args.done }),
+    // Move between projects — must be part of the full-model payload or Vikunja ignores it
+    ...(args.projectId !== undefined && { project_id: args.projectId }),
     // Handle repeat configuration for updates
     ...(args.repeatAfter !== undefined || args.repeatMode !== undefined
       ? ((): Record<string, unknown> => {

--- a/tests/tools/tasks-crud-auth-errors.test.ts
+++ b/tests/tools/tasks-crud-auth-errors.test.ts
@@ -75,6 +75,7 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
         updateTask: jest.fn(),
         deleteTask: jest.fn(),
         updateTaskLabels: jest.fn(),
+        addLabelToTask: jest.fn(),
         bulkAssignUsersToTask: jest.fn(),
         removeUserFromTask: jest.fn(),
       },
@@ -91,7 +92,7 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
       
       // Mock label assignment failure with 401 auth error
       const authError = createAuthError(401, 'Unauthorized to assign labels');
-      mockClient.tasks.updateTaskLabels.mockRejectedValue(authError);
+      mockClient.tasks.addLabelToTask.mockRejectedValue(authError);
       
       // Mock successful task deletion for rollback
       mockClient.tasks.deleteTask.mockResolvedValue(undefined);
@@ -104,7 +105,7 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
         })
       ).rejects.toThrow(MCPError);
 
-      // Verify the error message includes retry information
+      // Verify the error message includes authentication guidance
       try {
         await createTask({
           projectId: 1,
@@ -113,7 +114,6 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
         });
       } catch (error) {
         expect(error).toBeInstanceOf(MCPError);
-        expect((error as MCPError).message).toContain('(Retried');
         expect((error as MCPError).message).toContain('Task ID: 1');
       }
 
@@ -128,7 +128,7 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
       
       // Mock label assignment failure with 403 Axios-style auth error
       const authError = createAxiosAuthError(403, 'Forbidden to assign labels');
-      mockClient.tasks.updateTaskLabels.mockRejectedValue(authError);
+      mockClient.tasks.addLabelToTask.mockRejectedValue(authError);
       
       // Mock successful task deletion for rollback
       mockClient.tasks.deleteTask.mockResolvedValue(undefined);
@@ -149,7 +149,7 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
       // Mock successful task creation and label assignment
       const createdTask = { id: 1, title: 'Test Task', project_id: 1 };
       mockClient.tasks.createTask.mockResolvedValue(createdTask);
-      mockClient.tasks.updateTaskLabels.mockResolvedValue(undefined);
+      mockClient.tasks.addLabelToTask.mockResolvedValue(undefined);
       
       // Mock assignee assignment failure with 401 auth error
       const authError = createAuthError(401, 'Unauthorized to assign users');
@@ -396,7 +396,7 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
       
       // Mock label assignment failure with non-auth error
       const nonAuthError = new Error('Network timeout');
-      mockClient.tasks.updateTaskLabels.mockRejectedValue(nonAuthError);
+      mockClient.tasks.addLabelToTask.mockRejectedValue(nonAuthError);
       
       // Mock successful task deletion for rollback
       mockClient.tasks.deleteTask.mockResolvedValue(undefined);
@@ -441,27 +441,23 @@ describe('Tasks CRUD - Authentication Error Handling', () => {
   });
 
   describe('edge cases for complete coverage', () => {
-    it('should handle createTask with undefined task ID in error context', async () => {
+    it('should fail createTask when labels requested but task has no ID', async () => {
       // Mock task creation returning undefined/null ID
       const createdTaskNoId = { title: 'Test Task', project_id: 1, id: undefined };
       mockClient.tasks.createTask.mockResolvedValue(createdTaskNoId);
 
-      // When task has no ID, label assignment should not be attempted
-      const result = await createTask({
-        projectId: 1,
-        title: 'Test Task',
-        labels: [1],
-      });
+      await expect(
+        createTask({
+          projectId: 1,
+          title: 'Test Task',
+          labels: [1],
+        }),
+      ).rejects.toThrow('did not return a task id');
 
       // Verify no label operations were attempted due to missing task ID
-      expect(mockClient.tasks.updateTaskLabels).not.toHaveBeenCalled();
+      expect(mockClient.tasks.addLabelToTask).not.toHaveBeenCalled();
       // Verify no deleteTask call was made since there's no ID
       expect(mockClient.tasks.deleteTask).not.toHaveBeenCalled();
-
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
     });
 
     it('should handle updateTask with task having no assignees field', async () => {

--- a/tests/tools/tasks-crud-edge-cases.test.ts
+++ b/tests/tools/tasks-crud-edge-cases.test.ts
@@ -39,6 +39,7 @@ describe('Tasks CRUD - Edge Cases and Defensive Programming', () => {
         updateTask: jest.fn(),
         deleteTask: jest.fn(),
         updateTaskLabels: jest.fn(),
+        addLabelToTask: jest.fn(),
         bulkAssignUsersToTask: jest.fn(),
         removeUserFromTask: jest.fn(),
       },
@@ -139,7 +140,7 @@ describe('Tasks CRUD - Edge Cases and Defensive Programming', () => {
       });
 
       // Empty arrays should not trigger label/assignee operations
-      expect(mockClient.tasks.updateTaskLabels).not.toHaveBeenCalled();
+      expect(mockClient.tasks.addLabelToTask).not.toHaveBeenCalled();
       expect(mockClient.tasks.bulkAssignUsersToTask).not.toHaveBeenCalled();
 
       const markdown = result.content[0].text;
@@ -148,44 +149,37 @@ describe('Tasks CRUD - Edge Cases and Defensive Programming', () => {
       expect(aorpStatus.type).toBe('success');
     });
 
-    it('should handle task creation without ID for label operations', async () => {
+    it('should fail when labels are requested but task has no ID', async () => {
       const createdTaskNoId = { title: 'Test Task', project_id: 1 }; // No ID
       mockClient.tasks.createTask.mockResolvedValue(createdTaskNoId);
 
-      const result = await createTask({
-        projectId: 1,
-        title: 'Test Task',
-        labels: [1, 2], // Labels provided but task has no ID
-      });
+      await expect(
+        createTask({
+          projectId: 1,
+          title: 'Test Task',
+          labels: [1, 2], // Labels provided but task has no ID
+        }),
+      ).rejects.toThrow('did not return a task id');
 
       // Should not attempt label operations without task ID
-      expect(mockClient.tasks.updateTaskLabels).not.toHaveBeenCalled();
+      expect(mockClient.tasks.addLabelToTask).not.toHaveBeenCalled();
       expect(mockClient.tasks.getTask).not.toHaveBeenCalled();
-
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
     });
 
-    it('should handle task creation without ID for assignee operations', async () => {
+    it('should fail when assignees are requested but task has no ID', async () => {
       const createdTaskNoId = { title: 'Test Task', project_id: 1 }; // No ID
       mockClient.tasks.createTask.mockResolvedValue(createdTaskNoId);
 
-      const result = await createTask({
-        projectId: 1,
-        title: 'Test Task',
-        assignees: [1, 2], // Assignees provided but task has no ID
-      });
+      await expect(
+        createTask({
+          projectId: 1,
+          title: 'Test Task',
+          assignees: [1, 2], // Assignees provided but task has no ID
+        }),
+      ).rejects.toThrow('did not return a task id');
 
-      // Should not attempt assignee operations without task ID
       expect(mockClient.tasks.bulkAssignUsersToTask).not.toHaveBeenCalled();
       expect(mockClient.tasks.getTask).not.toHaveBeenCalled();
-
-      const markdown = result.content[0].text;
-      const parsed = parseMarkdown(markdown);
-      const aorpStatus = parsed.getAorpStatus();
-      expect(aorpStatus.type).toBe('success');
     });
   });
 
@@ -514,7 +508,7 @@ describe('Tasks CRUD - Edge Cases and Defensive Programming', () => {
       
       // Mock label assignment failure
       const labelError = new Error('Label assignment failed');
-      mockClient.tasks.updateTaskLabels.mockRejectedValue(labelError);
+      mockClient.tasks.addLabelToTask.mockRejectedValue(labelError);
       
       // Mock failed rollback
       const deleteError = new Error('Delete failed');

--- a/tests/tools/tasks-race-condition.test.ts
+++ b/tests/tools/tasks-race-condition.test.ts
@@ -16,6 +16,15 @@ jest.mock('../../src/client', () => ({
   clearGlobalClientFactory: jest.fn(),
 }));
 
+// Avoid shared "anonymous" circuit breaker replaying stale ops across tests
+jest.mock('../../src/utils/retry', () => {
+  const actual = jest.requireActual('../../src/utils/retry');
+  return {
+    ...actual,
+    withRetry: jest.fn().mockImplementation((fn: () => Promise<unknown>) => fn()),
+  };
+});
+
 // Import the mocked functions
 import { getClientFromContext } from '../../src/client';
 
@@ -67,6 +76,7 @@ describe('Tasks Tool - Race Condition Fix', () => {
         getProjectTasks: jest.fn(),
         createTask: jest.fn(),
         updateTaskLabels: jest.fn(),
+        addLabelToTask: jest.fn(),
         bulkAssignUsersToTask: jest.fn(),
         getTask: jest.fn(),
         deleteTask: jest.fn(),
@@ -108,7 +118,7 @@ describe('Tasks Tool - Race Condition Fix', () => {
       };
 
       mockClient.tasks.createTask.mockResolvedValue(createdTask);
-      mockClient.tasks.updateTaskLabels.mockRejectedValue(new Error('Label assignment failed'));
+      mockClient.tasks.addLabelToTask.mockRejectedValue(new Error('Label assignment failed'));
 
       const args = {
         subcommand: 'create',
@@ -135,7 +145,7 @@ describe('Tasks Tool - Race Condition Fix', () => {
       };
 
       mockClient.tasks.createTask.mockResolvedValue(createdTask);
-      mockClient.tasks.updateTaskLabels.mockResolvedValue({});
+      mockClient.tasks.addLabelToTask.mockResolvedValue({});
       mockClient.tasks.bulkAssignUsersToTask.mockRejectedValue(new Error('User assignment failed'));
 
       const args = {
@@ -164,7 +174,7 @@ describe('Tasks Tool - Race Condition Fix', () => {
       };
 
       mockClient.tasks.createTask.mockResolvedValue(createdTask);
-      mockClient.tasks.updateTaskLabels.mockRejectedValue(new Error('Label assignment failed'));
+      mockClient.tasks.addLabelToTask.mockRejectedValue(new Error('Label assignment failed'));
       mockClient.tasks.deleteTask.mockRejectedValue(new Error('Delete failed'));
 
       const args = {
@@ -216,7 +226,7 @@ describe('Tasks Tool - Race Condition Fix', () => {
       };
 
       mockClient.tasks.createTask.mockResolvedValue(createdTask);
-      mockClient.tasks.updateTaskLabels.mockResolvedValue({});
+      mockClient.tasks.addLabelToTask.mockResolvedValue({});
       mockClient.tasks.bulkAssignUsersToTask.mockResolvedValue({});
       mockClient.tasks.getTask.mockResolvedValue(completeTask);
 

--- a/tests/tools/tasks.test.ts
+++ b/tests/tools/tasks.test.ts
@@ -30,6 +30,15 @@ jest.mock('../../src/client', () => ({
 }));
 jest.mock('../../src/auth/AuthManager');
 
+// Avoid shared "anonymous" circuit breaker replaying stale ops across tests
+jest.mock('../../src/utils/retry', () => {
+  const actual = jest.requireActual('../../src/utils/retry');
+  return {
+    ...actual,
+    withRetry: jest.fn().mockImplementation((fn: () => Promise<unknown>) => fn()),
+  };
+});
+
 describe('Tasks Tool', () => {
   let mockClient: MockVikunjaClient;
   let mockAuthManager: MockAuthManager;
@@ -122,6 +131,8 @@ describe('Tasks Tool', () => {
         getTaskComments: jest.fn(),
         createTaskComment: jest.fn(),
         updateTaskLabels: jest.fn(),
+        addLabelToTask: jest.fn(),
+        removeLabelFromTask: jest.fn(),
         bulkAssignUsersToTask: jest.fn(),
         removeUserFromTask: jest.fn(),
         bulkUpdateTasks: jest.fn(),
@@ -380,8 +391,15 @@ describe('Tasks Tool', () => {
       };
 
       mockClient.tasks.createTask.mockResolvedValue({ ...mockTask, id: 1 });
-      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, ...fullTask });
-      mockClient.tasks.updateTaskLabels.mockResolvedValue(undefined);
+      mockClient.tasks.getTask.mockResolvedValue({
+        ...mockTask,
+        ...fullTask,
+        labels: [
+          { id: 1, title: 'Label 1' },
+          { id: 2, title: 'Label 2' },
+        ],
+      });
+      mockClient.tasks.addLabelToTask.mockResolvedValue(undefined);
       mockClient.tasks.bulkAssignUsersToTask.mockResolvedValue(undefined);
 
       await callTool('create', fullTask);
@@ -393,6 +411,55 @@ describe('Tasks Tool', () => {
           project_id: 1,
         }),
       );
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledWith(1, {
+        task_id: 1,
+        label_id: 1,
+      });
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledWith(1, {
+        task_id: 1,
+        label_id: 2,
+      });
+      expect(mockClient.tasks.bulkAssignUsersToTask).toHaveBeenCalledWith(1, {
+        user_ids: [1, 2],
+      });
+    });
+
+    it('should apply labels on create and fail if they do not stick', async () => {
+      mockClient.tasks.createTask.mockResolvedValue({ ...mockTask, id: 1 });
+      mockClient.tasks.addLabelToTask.mockResolvedValue(undefined);
+      // API reports success but labels are missing on refetch
+      mockClient.tasks.getTask.mockResolvedValue({ ...mockTask, id: 1, labels: [] });
+      mockClient.tasks.deleteTask.mockResolvedValue(undefined);
+
+      await expect(
+        callTool('create', {
+          title: 'Test',
+          projectId: 1,
+          labels: [4, 3],
+        }),
+      ).rejects.toThrow('Labels were requested but not attached');
+
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledWith(1, {
+        task_id: 1,
+        label_id: 4,
+      });
+      expect(mockClient.tasks.addLabelToTask).toHaveBeenCalledWith(1, {
+        task_id: 1,
+        label_id: 3,
+      });
+      expect(mockClient.tasks.deleteTask).toHaveBeenCalledWith(1);
+    });
+
+    it('should fail create when labels are requested but task has no id', async () => {
+      mockClient.tasks.createTask.mockResolvedValue({ ...mockTask, id: undefined });
+
+      await expect(
+        callTool('create', {
+          title: 'Test',
+          projectId: 1,
+          labels: [1],
+        }),
+      ).rejects.toThrow('did not return a task id');
     });
 
     it('should validate required fields', async () => {
@@ -443,7 +510,7 @@ describe('Tasks Tool', () => {
 
     it('should rollback task creation when label assignment fails', async () => {
       mockClient.tasks.createTask.mockResolvedValue({ ...mockTask, id: 1 });
-      mockClient.tasks.updateTaskLabels.mockRejectedValue(new Error('Label assignment failed'));
+      mockClient.tasks.addLabelToTask.mockRejectedValue(new Error('Label assignment failed'));
       mockClient.tasks.deleteTask.mockResolvedValue(undefined);
 
       await expect(
@@ -452,9 +519,7 @@ describe('Tasks Tool', () => {
           projectId: 1,
           labels: [1, 2],
         }),
-      ).rejects.toThrow(
-        "Circuit breaker"
-      );
+      ).rejects.toThrow('Failed to complete task creation: Label assignment failed');
 
       expect(mockClient.tasks.deleteTask).toHaveBeenCalledWith(1);
     });
@@ -464,7 +529,7 @@ describe('Tasks Tool', () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
       mockClient.tasks.createTask.mockResolvedValue({ ...mockTask, id: 1 });
-      mockClient.tasks.updateTaskLabels.mockResolvedValue(undefined);
+      mockClient.tasks.addLabelToTask.mockResolvedValue(undefined);
       mockClient.tasks.bulkAssignUsersToTask.mockRejectedValue(
         new Error('Assignee assignment failed'),
       );
@@ -477,9 +542,7 @@ describe('Tasks Tool', () => {
           labels: [1],
           assignees: [1, 2],
         }),
-      ).rejects.toThrow(
-        "Circuit breaker"
-      );
+      ).rejects.toThrow('Failed to complete task creation: Assignee assignment failed');
 
       expect(mockClient.tasks.deleteTask).toHaveBeenCalledWith(1);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -514,7 +577,7 @@ describe('Tasks Tool', () => {
 
     it('should handle non-Error failures during label assignment', async () => {
       mockClient.tasks.createTask.mockResolvedValue({ ...mockTask, id: 1 });
-      mockClient.tasks.updateTaskLabels.mockRejectedValue('Label update failed');
+      mockClient.tasks.addLabelToTask.mockRejectedValue('Label update failed');
       mockClient.tasks.deleteTask.mockResolvedValue(undefined);
 
       await expect(
@@ -523,9 +586,7 @@ describe('Tasks Tool', () => {
           projectId: 1,
           labels: [1, 2],
         }),
-      ).rejects.toThrow(
-        "Circuit breaker"
-      );
+      ).rejects.toThrow('Failed to complete task creation: Label update failed');
 
       expect(mockClient.tasks.deleteTask).toHaveBeenCalledWith(1);
     });
@@ -822,6 +883,71 @@ describe('Tasks Tool', () => {
       const parsed = parseMarkdown(markdown);
       const aorpStatus = parsed.getAorpStatus();
       expect(aorpStatus.type).toBe('success');
+    });
+
+    it('should move a task to another project via projectId', async () => {
+      // GitHub #37 / Vikunja #442 — projectId was previously ignored on update
+      const taskInProjectA = {
+        ...mockTask,
+        project_id: 8,
+        description: 'Keep me',
+        priority: 3,
+        done: false,
+      };
+      const movedTask = {
+        ...taskInProjectA,
+        project_id: 5,
+      };
+
+      mockClient.tasks.getTask
+        .mockResolvedValueOnce(taskInProjectA)
+        .mockResolvedValueOnce(movedTask);
+      mockClient.tasks.updateTask.mockResolvedValue(movedTask);
+
+      const result = await callTool('update', {
+        id: 1,
+        projectId: 5,
+      });
+
+      // Full-model merge must include project_id so Vikunja applies the move
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(1, {
+        ...taskInProjectA,
+        project_id: 5,
+      });
+
+      const markdown = result.content[0].text;
+      const parsed = parseMarkdown(markdown);
+      expect(parsed.getAorpStatus().type).toBe('success');
+      expect(markdown).toContain('projectId');
+    });
+
+    it('should fail loudly if project move does not stick', async () => {
+      const taskInProjectA = {
+        ...mockTask,
+        project_id: 8,
+      };
+
+      mockClient.tasks.getTask
+        .mockResolvedValueOnce(taskInProjectA)
+        // API acknowledges update but task stays in original project
+        .mockResolvedValueOnce(taskInProjectA);
+      mockClient.tasks.updateTask.mockResolvedValue(taskInProjectA);
+
+      await expect(
+        callTool('update', {
+          id: 1,
+          projectId: 5,
+        }),
+      ).rejects.toThrow('Failed to move task 1 to project 5');
+    });
+
+    it('should validate projectId when moving a task', async () => {
+      await expect(
+        callTool('update', {
+          id: 1,
+          projectId: -1,
+        }),
+      ).rejects.toThrow('projectId must be a positive integer');
     });
 
     it('should handle label updates', async () => {


### PR DESCRIPTION
## Summary
- `update` with `projectId` previously ignored the move and still reported success — risk of permanent data loss if the old project was then deleted
- Merge `project_id` into the full-model update payload (Vikunja replaces the whole task) and re-fetch afterward; error if the project did not change
- `create` with `labels` now uses `addLabelToTask` (same path as `apply-label`) instead of `updateTaskLabels`, which could silently no-op, and rolls back if labels do not stick

Fixes #37

## Test plan
- [x] Unit: update with `projectId` sends merged payload including `project_id`
- [x] Unit: update errors when move did not stick after GET
- [x] Unit: invalid `projectId` rejected
- [x] Unit: create applies labels via `addLabelToTask` and asserts call
- [x] Unit: create rolls back when labels missing after refetch
- [x] Unit: create fails when labels requested but task has no id
- [x] `npm run typecheck` and `npm run lint` pass
- [ ] Manual: create with `labels` → `list-labels` shows them
- [ ] Manual: update `projectId` → task appears in target project