### PR TITLE
fix(test-mcp): align labels and archive with Vikunja 2.3

### DIFF
--- a/scripts/test-mcp.ts
+++ b/scripts/test-mcp.ts
@@ -344,14 +344,12 @@ async function testTaskLabels(): Promise<void> {
     return;
   }
 
-  // Apply single label
+  // Apply single label (Vikunja 2.x: PUT /tasks/{id}/labels with body, not …/labels/{labelId})
   try {
-    await api('PUT', `/tasks/${taskId}/labels/${labelId}`, { label_id: labelId });
+    await api('PUT', `/tasks/${taskId}/labels`, { label_id: labelId });
 
-    // Read back and verify
-    const task = await api<{ labels: Array<{ id: number }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
-    if (!labels.some(l => l.id === labelId)) {
+    const labels = await api<Array<{ id: number }>>('GET', `/tasks/${taskId}/labels`);
+    if (!labels.some((l) => l.id === labelId)) {
       fail('apply single label', 'label not found on task after apply');
     } else {
       pass('apply single label');
@@ -362,10 +360,9 @@ async function testTaskLabels(): Promise<void> {
 
   // Apply second label
   try {
-    await api('PUT', `/tasks/${taskId}/labels/${labelId2}`, { label_id: labelId2 });
+    await api('PUT', `/tasks/${taskId}/labels`, { label_id: labelId2 });
 
-    const task = await api<{ labels: Array<{ id: number }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
+    const labels = await api<Array<{ id: number }>>('GET', `/tasks/${taskId}/labels`);
     if (labels.length < 2) {
       fail('apply multiple labels', `expected 2 labels, got ${labels.length}`);
     } else {
@@ -379,9 +376,8 @@ async function testTaskLabels(): Promise<void> {
   try {
     await api('DELETE', `/tasks/${taskId}/labels/${labelId}`);
 
-    const task = await api<{ labels: Array<{ id: number }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
-    if (labels.some(l => l.id === labelId)) {
+    const labels = await api<Array<{ id: number }>>('GET', `/tasks/${taskId}/labels`);
+    if (labels.some((l) => l.id === labelId)) {
       fail('remove label', 'label still present after remove');
     } else {
       pass('remove label');
@@ -392,8 +388,10 @@ async function testTaskLabels(): Promise<void> {
 
   // List labels on task
   try {
-    const task = await api<{ labels: Array<{ id: number; title: string }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
+    const labels = await api<Array<{ id: number; title: string }>>(
+      'GET',
+      `/tasks/${taskId}/labels`
+    );
     if (labels.length !== 1) {
       fail('list task labels', `expected 1 label, got ${labels.length}`);
     } else if (labels[0].id !== labelId2) {
@@ -576,9 +574,13 @@ async function testProjects(): Promise<void> {
     fail('update project', (e as Error).message);
   }
 
-  // Archive project
+  // Archive project (Vikunja requires title on update — sparse is_archived alone → 412)
   try {
-    await api('POST', `/projects/${projectId}`, { is_archived: true });
+    const current = await api<{ title: string }>('GET', `/projects/${projectId}`);
+    await api('POST', `/projects/${projectId}`, {
+      title: current.title,
+      is_archived: true,
+    });
 
     const project = await api<{ is_archived: boolean }>('GET', `/projects/${projectId}`);
     if (!project.is_archived) {
@@ -586,7 +588,10 @@ async function testProjects(): Promise<void> {
     } else {
       pass('archive project');
       // Unarchive for cleanup
-      await api('POST', `/projects/${projectId}`, { is_archived: false });
+      await api('POST', `/projects/${projectId}`, {
+        title: current.title,
+        is_archived: false,
+      });
     }
   } catch (e) {
     fail('archive project', (e as Error).message);


### PR DESCRIPTION
## Description
Update `scripts/test-mcp.ts` for Vikunja 2.x:
- Label routes: `PUT /tasks/{id}/labels`, `GET …/labels`
- Archive/unarchive sends `title` with `is_archived` (Vikunja validation; related to #44)

## Related Issue
Part of #68 (Dockerized MCP integration CI stack).

## Motivation and Context
The integration suite was written against older label URL shapes. Against Vikunja 2.3 those calls return 405; sparse archive returns 412. This unblocks #67 (ephemeral Docker MCP CI).

## How Has This Been Tested?
- [x] Verified green on fork against ephemeral Vikunja 2.3.0 (23/23)
- [ ] Review the two call-site changes in `scripts/test-mcp.ts`
- [ ] (Optional) `VIKUNJA_URL=… VIKUNJA_API_TOKEN=… npm run test:mcp` against Vikunja 2.3

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactor
- [ ] Performance improvement

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
