### PR TITLE
test(mcp): ephemeral Docker Vikunja integration CI

### DIFF
--- a/.github/workflows/mcp-integration.yml
+++ b/.github/workflows/mcp-integration.yml
@@ -1,0 +1,38 @@
+name: MCP Integration
+
+# Live integration tests against an ephemeral Dockerized Vikunja.
+# No secrets: register + login mint a JWT at runtime. See docs/MCP-INTEGRATION-CI.md.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mcp-integration:
+    name: Vikunja + MCP suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Start Vikunja, run MCP tests, tear down
+        run: npm run test:mcp

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ yarn-error.log*
 .env
 .env.local
 .env.*.local
+.env.e2e
 
 # Test coverage
 coverage/

--- a/docker/vikunja.e2e.yml
+++ b/docker/vikunja.e2e.yml
@@ -1,0 +1,22 @@
+# Ephemeral Vikunja for MCP integration tests. SQLite on tmpfs so every run
+# starts clean. Image is overridable via VIKUNJA_IMAGE.
+#
+#   docker compose -p vikunja-mcp-e2e -f docker/vikunja.e2e.yml up -d
+#   docker compose -p vikunja-mcp-e2e -f docker/vikunja.e2e.yml down -v
+#
+# No default user — scripts/vikunja-docker.ts registers one and mints a JWT.
+services:
+  vikunja:
+    image: ${VIKUNJA_IMAGE:-vikunja/vikunja:2.3.0}
+    container_name: vikunja-mcp-e2e
+    ports:
+      - '${VIKUNJA_PORT:-3456}:3456'
+    environment:
+      VIKUNJA_SERVICE_PUBLICURL: 'http://localhost:${VIKUNJA_PORT:-3456}/'
+      VIKUNJA_SERVICE_JWTSECRET: e2e-ci-not-a-secret
+      VIKUNJA_SERVICE_ENABLEREGISTRATION: 'true'
+      VIKUNJA_DATABASE_TYPE: sqlite
+      VIKUNJA_DATABASE_PATH: /db/vikunja.db
+    tmpfs:
+      - /db:uid=1000,gid=1000,mode=0755
+      - /app/vikunja/files:uid=1000,gid=1000,mode=0755

--- a/docs/MCP-INTEGRATION-CI.md
+++ b/docs/MCP-INTEGRATION-CI.md
@@ -1,0 +1,50 @@
+# MCP Integration CI
+
+Live tests against a **real Vikunja** in ephemeral Docker. Unit/coverage CI
+(`.github/workflows/ci.yml`) stays mocked; this gate catches API drift.
+
+## Pattern (same idea as mini-mealie’s Mealie E2E)
+
+1. `docker/vikunja.e2e.yml` — pinned Vikunja (`2.3.0`), SQLite on tmpfs.
+2. `scripts/vikunja-docker.ts` — `up` / `down`: wait for health, register a
+   user, mint a JWT via login, write `.env.e2e` (**no secrets**).
+3. `scripts/test-mcp.ts` — loads `.env.e2e` if present; runs the suite.
+4. `.github/workflows/mcp-integration.yml` — `npm run test:mcp` on every PR.
+
+## Commands
+
+Full cycle (up → test → down):
+
+```
+npm run test:mcp
+```
+
+Manual control:
+
+```
+npm run test:mcp:up
+npm run test:mcp:run
+npm run test:mcp:down
+```
+
+Point at any Vikunja instead of Docker (env wins over `.env.e2e`):
+
+```
+export VIKUNJA_URL=https://example.com/api/v1
+export VIKUNJA_API_TOKEN=tk_...
+npm run test:mcp:run
+```
+
+## Useful env vars
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `VIKUNJA_URL` / `VIKUNJA_API_TOKEN` | from `.env.e2e` | Target instance |
+| `VIKUNJA_IMAGE` | `vikunja/vikunja:2.3.0` | Docker image (pin for a stable gate) |
+| `VIKUNJA_PORT` | `3456` | Host port for the container |
+
+## CI notes
+
+- Docker + Compose ship on `ubuntu-latest`.
+- Pinned image so a red PR means *your* change broke, not an upstream release.
+- Existing lint / typecheck / coverage job is unchanged.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "version:patch": "npm version patch",
     "version:minor": "npm version minor",
     "version:major": "npm version major",
-    "test:mcp": "tsx scripts/test-mcp.ts"
+    "test:mcp:up": "tsx scripts/vikunja-docker.ts up",
+    "test:mcp:down": "tsx scripts/vikunja-docker.ts down",
+    "test:mcp:run": "tsx scripts/test-mcp.ts",
+    "test:mcp": "npm run test:mcp:up && (npm run test:mcp:run; ec=$?; npm run test:mcp:down; exit $ec)"
   },
   "keywords": [
     "mcp",

--- a/scripts/test-mcp.ts
+++ b/scripts/test-mcp.ts
@@ -344,14 +344,12 @@ async function testTaskLabels(): Promise<void> {
     return;
   }
 
-  // Apply single label
+  // Apply single label (Vikunja 2.x: PUT /tasks/{id}/labels with body, not …/labels/{labelId})
   try {
-    await api('PUT', `/tasks/${taskId}/labels/${labelId}`, { label_id: labelId });
+    await api('PUT', `/tasks/${taskId}/labels`, { label_id: labelId });
 
-    // Read back and verify
-    const task = await api<{ labels: Array<{ id: number }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
-    if (!labels.some(l => l.id === labelId)) {
+    const labels = await api<Array<{ id: number }>>('GET', `/tasks/${taskId}/labels`);
+    if (!labels.some((l) => l.id === labelId)) {
       fail('apply single label', 'label not found on task after apply');
     } else {
       pass('apply single label');
@@ -362,10 +360,9 @@ async function testTaskLabels(): Promise<void> {
 
   // Apply second label
   try {
-    await api('PUT', `/tasks/${taskId}/labels/${labelId2}`, { label_id: labelId2 });
+    await api('PUT', `/tasks/${taskId}/labels`, { label_id: labelId2 });
 
-    const task = await api<{ labels: Array<{ id: number }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
+    const labels = await api<Array<{ id: number }>>('GET', `/tasks/${taskId}/labels`);
     if (labels.length < 2) {
       fail('apply multiple labels', `expected 2 labels, got ${labels.length}`);
     } else {
@@ -379,9 +376,8 @@ async function testTaskLabels(): Promise<void> {
   try {
     await api('DELETE', `/tasks/${taskId}/labels/${labelId}`);
 
-    const task = await api<{ labels: Array<{ id: number }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
-    if (labels.some(l => l.id === labelId)) {
+    const labels = await api<Array<{ id: number }>>('GET', `/tasks/${taskId}/labels`);
+    if (labels.some((l) => l.id === labelId)) {
       fail('remove label', 'label still present after remove');
     } else {
       pass('remove label');
@@ -392,8 +388,10 @@ async function testTaskLabels(): Promise<void> {
 
   // List labels on task
   try {
-    const task = await api<{ labels: Array<{ id: number; title: string }> | null }>('GET', `/tasks/${taskId}`);
-    const labels = task.labels || [];
+    const labels = await api<Array<{ id: number; title: string }>>(
+      'GET',
+      `/tasks/${taskId}/labels`
+    );
     if (labels.length !== 1) {
       fail('list task labels', `expected 1 label, got ${labels.length}`);
     } else if (labels[0].id !== labelId2) {
@@ -576,9 +574,13 @@ async function testProjects(): Promise<void> {
     fail('update project', (e as Error).message);
   }
 
-  // Archive project
+  // Archive project (Vikunja requires title on update — sparse is_archived alone → 412)
   try {
-    await api('POST', `/projects/${projectId}`, { is_archived: true });
+    const current = await api<{ title: string }>('GET', `/projects/${projectId}`);
+    await api('POST', `/projects/${projectId}`, {
+      title: current.title,
+      is_archived: true,
+    });
 
     const project = await api<{ is_archived: boolean }>('GET', `/projects/${projectId}`);
     if (!project.is_archived) {
@@ -586,7 +588,10 @@ async function testProjects(): Promise<void> {
     } else {
       pass('archive project');
       // Unarchive for cleanup
-      await api('POST', `/projects/${projectId}`, { is_archived: false });
+      await api('POST', `/projects/${projectId}`, {
+        title: current.title,
+        is_archived: false,
+      });
     }
   } catch (e) {
     fail('archive project', (e as Error).message);

--- a/scripts/test-mcp.ts
+++ b/scripts/test-mcp.ts
@@ -1,12 +1,43 @@
 #!/usr/bin/env npx tsx
 /**
  * MCP Integration Test Suite
- * Tests vikunja-mcp tools against a real Vikunja instance
+ * Tests against a real Vikunja instance (Docker via scripts/vikunja-docker.ts
+ * or any instance pointed at by VIKUNJA_URL / VIKUNJA_API_TOKEN).
  */
+
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // ============================================================================
 // Configuration
 // ============================================================================
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
+
+/**
+ * Load `.env.e2e` (written by `vikunja-docker.ts up`) into `process.env`.
+ * Existing env vars win, so an explicit `VIKUNJA_URL=...` on the command line
+ * overrides the Docker-minted values.
+ */
+function loadE2eEnv(): void {
+  const file = path.join(REPO_ROOT, '.env.e2e');
+  if (!existsSync(file)) return;
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (key && process.env[key] === undefined) process.env[key] = value;
+  }
+}
+
+loadE2eEnv();
 
 const CONFIG = {
   apiUrl: process.env.VIKUNJA_URL || '',

--- a/scripts/vikunja-docker.ts
+++ b/scripts/vikunja-docker.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env npx tsx
+/**
+ * Ephemeral Dockerized Vikunja for MCP integration tests:
+ * bring it up, register a user, mint a JWT, tear it down.
+ *
+ *   npx tsx scripts/vikunja-docker.ts up     # start + write .env.e2e
+ *   npx tsx scripts/vikunja-docker.ts down   # stop + remove volumes
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const COMPOSE_FILE = path.join(REPO_ROOT, 'docker/vikunja.e2e.yml');
+const PROJECT_NAME = 'vikunja-mcp-e2e';
+const VIKUNJA_PORT = process.env.VIKUNJA_PORT?.trim() || '3456';
+const VIKUNJA_BASE = `http://localhost:${VIKUNJA_PORT}`;
+const API_BASE = `${VIKUNJA_BASE}/api/v1`;
+const ENV_FILE = path.join(REPO_ROOT, '.env.e2e');
+
+const E2E_USER = {
+  username: 'mcpe2e',
+  email: 'mcpe2e@example.com',
+  password: 'mcp-e2e-password-1',
+};
+
+function compose(args: string[]): void {
+  execFileSync(
+    'docker',
+    ['compose', '-p', PROJECT_NAME, '-f', COMPOSE_FILE, ...args],
+    { stdio: 'inherit', cwd: REPO_ROOT }
+  );
+}
+
+async function waitForHealthy(timeoutMs = 120_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${API_BASE}/info`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  throw new Error(`Vikunja did not become healthy at ${API_BASE} within ${timeoutMs}ms`);
+}
+
+async function registerUser(): Promise<void> {
+  const res = await fetch(`${API_BASE}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(E2E_USER),
+  });
+  // 200 = created; 400 = already exists (re-running up without down)
+  if (res.ok || res.status === 400) return;
+  throw new Error(`Vikunja register failed: ${res.status} ${await res.text()}`);
+}
+
+async function login(): Promise<string> {
+  const res = await fetch(`${API_BASE}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: E2E_USER.username,
+      password: E2E_USER.password,
+    }),
+  });
+  if (!res.ok) throw new Error(`Vikunja login failed: ${res.status} ${await res.text()}`);
+  const data = (await res.json()) as { token?: string };
+  if (!data.token) throw new Error('Vikunja login returned no token');
+  return data.token;
+}
+
+export type VikunjaHandle = { url: string; token: string };
+
+/**
+ * Start Vikunja (if not already up), wait for health, register a user, and
+ * mint a JWT via login. JWT works as Bearer auth (same as an API token) and
+ * avoids version-specific API-token permission lists.
+ */
+export async function vikunjaUp(): Promise<VikunjaHandle> {
+  compose(['up', '-d']);
+  await waitForHealthy();
+  await registerUser();
+  const token = await login();
+  return { url: API_BASE, token };
+}
+
+/** Stop Vikunja and remove its (tmpfs) volumes. */
+export function vikunjaDown(): void {
+  compose(['down', '-v']);
+}
+
+async function main(): Promise<void> {
+  const cmd = process.argv[2];
+  if (cmd === 'up') {
+    const { url, token } = await vikunjaUp();
+    writeFileSync(
+      ENV_FILE,
+      `VIKUNJA_URL=${url}\nVIKUNJA_API_TOKEN=${token}\n`
+    );
+    console.log(`[vikunja] up at ${url} — creds written to .env.e2e`);
+  } else if (cmd === 'down') {
+    vikunjaDown();
+    console.log('[vikunja] down');
+  } else {
+    console.error('usage: tsx scripts/vikunja-docker.ts <up|down>');
+    process.exit(1);
+  }
+}
+
+const thisFile = fileURLToPath(import.meta.url);
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === thisFile;
+
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Description
Ephemeral Dockerized Vikunja for live MCP integration tests:
- `docker/vikunja.e2e.yml` — pinned `vikunja/vikunja:2.3.0`, SQLite on tmpfs
- `scripts/vikunja-docker.ts` — up/down: health wait, register user, mint JWT → `.env.e2e` (**no secrets**)
- `npm run test:mcp` = up → suite → down
- `.github/workflows/mcp-integration.yml` on PR/push to main/develop
- Docs: `docs/MCP-INTEGRATION-CI.md`

## Related Issue
Implements the PR-gate portion of #68.

## Motivation and Context
Unit CI is mocked; this gate catches real Vikunja API drift. Closes the README item “Add integration tests with a real Vikunja instance.”

## Depends on
Stacks on **#66**. That suite fix is included in this branch so CI is green even before #66 merges; after #66 lands, this PR is Docker/CI + `.env.e2e` loading only.

## How Has This Been Tested?
- [x] Verified on fork: https://github.com/joyjit/vikunja-mcp/actions/runs/29533090621 (23 passed, 0 failed)
- [ ] Review Compose pin + token bootstrap (register/login JWT)
- [ ] Confirm workflow does not require repo secrets
- [ ] After merge, optional: `workflow_dispatch` or PR to exercise Actions on this repo

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactor
- [ ] Performance improvement

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
