### PR TITLE
fix: include all list items in success responses (#85)

### DIFF
--- a/src/utils/simple-response.ts
+++ b/src/utils/simple-response.ts
@@ -125,12 +125,13 @@ export function formatSuccessMessage(
 
     if (collection && Array.isArray(collection)) {
       content += `**Results:** ${collection.length} item(s)\n\n`;
-      if (collection.length > 0 && collection.length <= 10) {
+      // Always render items — a <=10 cap previously dropped data (#85).
+      if (collection.length > 0) {
         content += formatDataItems(collection as DataItem[]);
       }
     } else if (Array.isArray(data)) {
       content += `**Results:** ${data.length} item(s)\n\n`;
-      if (data.length > 0 && data.length <= 10) {
+      if (data.length > 0) {
         content += formatDataItems(data as DataItem[]);
       }
     } else if (data && typeof data === 'object') {

--- a/tests/utils/simple-response.test.ts
+++ b/tests/utils/simple-response.test.ts
@@ -346,7 +346,7 @@ describe('simple-response - Task Formatting', () => {
       expect(result).toContain('0 item(s)');
     });
 
-    it('should handle more than 10 items (should not display)', () => {
+    it('should display all items when collection has more than 10', () => {
       const tasks: Task[] = Array.from({ length: 15 }, (_, i) => ({
         id: i + 1,
         project_id: 1,
@@ -364,12 +364,14 @@ describe('simple-response - Task Formatting', () => {
 
       expect(result).toContain('**Results:**');
       expect(result).toContain('15 item(s)');
-      // Items should not be displayed when > 10
-      expect(result).not.toContain('### 1.');
-      expect(result).not.toContain('Task 1');
+      // Items must be included — dropping them was silent data loss (#85)
+      expect(result).toContain('### 1.');
+      expect(result).toContain('Task 1');
+      expect(result).toContain('### 15.');
+      expect(result).toContain('Task 15');
     });
 
-    it('should handle exactly 10 items (should display)', () => {
+    it('should display all items when collection has exactly 10', () => {
       const tasks: Task[] = Array.from({ length: 10 }, (_, i) => ({
         id: i + 1,
         project_id: 1,
@@ -387,11 +389,29 @@ describe('simple-response - Task Formatting', () => {
 
       expect(result).toContain('**Results:**');
       expect(result).toContain('10 item(s)');
-      // Items should be displayed when <= 10
       expect(result).toContain('### 1.');
       expect(result).toContain('Task 1');
       expect(result).toContain('### 10.');
       expect(result).toContain('Task 10');
+    });
+
+    it('should display all items for non-task collections over 10', () => {
+      const projects = Array.from({ length: 12 }, (_, i) => ({
+        id: i + 1,
+        name: `Project ${i + 1}`,
+      }));
+
+      const result = formatSuccessMessage(
+        'list-projects',
+        'Found 12 projects',
+        { projects },
+        { count: 12 }
+      );
+
+      expect(result).toContain('**Results:**');
+      expect(result).toContain('12 item(s)');
+      expect(result).toContain('1. **Project 1** (ID: 1)');
+      expect(result).toContain('12. **Project 12** (ID: 12)');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes [#85](https://github.com/democratize-technology/vikunja-mcp/issues/85): `formatSuccessMessage` dropped collection items when length was over 10, leaving only a count with no recoverable data.
- Always render all list items in the markdown success response.
- Updates/adds tests for >10 tasks, exactly 10 tasks, and >10 non-task collections.

Replaces the accidental multi-commit PR [#87](https://github.com/democratize-technology/vikunja-mcp/pull/87) (closed when the shared head branch was deleted after merging the equivalent fix on the fork).

## Test plan
- [x] `npx jest tests/utils/simple-response.test.ts`
- [x] `npm run lint` / `typecheck` / `test:coverage` on the fork equivalent
- [ ] Upstream CI green