### PR TITLE
fix: use /tasks for getAllTasks on Vikunja 2.x (fixes #40)

### DIFF
--- a/src/client/VikunjaClientFactory.ts
+++ b/src/client/VikunjaClientFactory.ts
@@ -6,6 +6,7 @@
 import type { VikunjaClient } from 'node-vikunja';
 import type { AuthManager } from '../auth/AuthManager';
 import type { VikunjaClientConstructor } from '../types/node-vikunja-extended';
+import { patchGetAllTasksForVikunja2 } from './patchGetAllTasks';
 
 /**
  * Factory for creating and managing Vikunja client instances
@@ -38,6 +39,8 @@ export class VikunjaClientFactory {
       }
       
       this.clientInstance = new this.VikunjaClientClass(session.apiUrl, session.apiToken);
+      // Vikunja 2.x: getAllTasks must use /tasks, not /tasks/all
+      patchGetAllTasksForVikunja2(this.clientInstance);
       this.currentApiUrl = session.apiUrl;
       this.currentApiToken = session.apiToken;
     }

--- a/src/client/patchGetAllTasks.ts
+++ b/src/client/patchGetAllTasks.ts
@@ -1,0 +1,31 @@
+/**
+ * node-vikunja 0.4.0 calls GET /tasks/all for getAllTasks().
+ * Vikunja 2.x does not serve that path (HTTP 400, code 2004).
+ * The correct path is GET /tasks.
+ *
+ * Remove this shim once node-vikunja publishes a fix
+ * (democratize-technology/node-vikunja#4 / vikunja-mcp#40).
+ */
+
+import type { GetTasksParams, Task, VikunjaClient } from 'node-vikunja';
+
+interface TaskServiceWithRequest {
+  getAllTasks(params?: GetTasksParams): Promise<Task[]>;
+  request(
+    endpoint: string,
+    method: string,
+    body?: unknown,
+    options?: { params?: GetTasksParams },
+  ): Promise<Task[]>;
+}
+
+export function patchGetAllTasksForVikunja2(client: VikunjaClient): void {
+  const tasks = client.tasks as unknown as TaskServiceWithRequest | undefined;
+  if (!tasks || typeof tasks.request !== 'function') {
+    return;
+  }
+
+  const request = tasks.request.bind(tasks);
+  tasks.getAllTasks = (params?: GetTasksParams): Promise<Task[]> =>
+    request('/tasks', 'GET', undefined, params !== undefined ? { params } : {});
+}

--- a/tests/client/VikunjaClientFactory.test.ts
+++ b/tests/client/VikunjaClientFactory.test.ts
@@ -318,6 +318,36 @@ describe('VikunjaClientFactory', () => {
     });
   });
 
+  describe('Vikunja 2.x getAllTasks path fix', () => {
+    it('rewrites getAllTasks to use /tasks when request exists', async () => {
+      const request = jest.fn().mockResolvedValue([{ id: 7, title: 'Patched' }]);
+      mockVikunjaClientConstructor.mockImplementation(() => ({
+        tasks: {
+          getAllTasks: jest.fn().mockRejectedValue(new Error('should not call original')),
+          request,
+        },
+        projects: {},
+        users: {},
+        labels: {},
+        teams: {},
+        webhooks: {},
+      }));
+
+      mockAuthManager.getSession.mockReturnValue({
+        apiUrl: 'https://test.vikunja.com',
+        apiToken: 'test-token',
+      });
+
+      const client = factory.getClient();
+      const tasks = await client.tasks.getAllTasks({ per_page: 5 });
+
+      expect(request).toHaveBeenCalledWith('/tasks', 'GET', undefined, {
+        params: { per_page: 5 },
+      });
+      expect(tasks).toEqual([{ id: 7, title: 'Patched' }]);
+    });
+  });
+
   describe('Constructor and Initialization', () => {
     it('should initialize with required dependencies', () => {
       expect(() => new VikunjaClientFactory(mockAuthManager, mockVikunjaClientConstructor))

--- a/tests/client/patchGetAllTasks.test.ts
+++ b/tests/client/patchGetAllTasks.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for Vikunja 2.x getAllTasks path shim (/tasks instead of /tasks/all)
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { patchGetAllTasksForVikunja2 } from '../../src/client/patchGetAllTasks';
+import type { VikunjaClient } from 'node-vikunja';
+
+describe('patchGetAllTasksForVikunja2', () => {
+  it('rewrites getAllTasks to call GET /tasks with params', async () => {
+    const request = jest.fn().mockResolvedValue([{ id: 1, title: 'Task' }]);
+    const client = {
+      tasks: {
+        getAllTasks: jest.fn(),
+        request,
+      },
+    } as unknown as VikunjaClient;
+
+    patchGetAllTasksForVikunja2(client);
+
+    const params = { per_page: 1, page: 2 };
+    const result = await client.tasks.getAllTasks(params);
+
+    expect(request).toHaveBeenCalledWith('/tasks', 'GET', undefined, { params });
+    expect(request).not.toHaveBeenCalledWith(
+      '/tasks/all',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(result).toEqual([{ id: 1, title: 'Task' }]);
+  });
+
+  it('omits params option when none are provided', async () => {
+    const request = jest.fn().mockResolvedValue([]);
+    const client = {
+      tasks: {
+        getAllTasks: jest.fn(),
+        request,
+      },
+    } as unknown as VikunjaClient;
+
+    patchGetAllTasksForVikunja2(client);
+    await client.tasks.getAllTasks();
+
+    expect(request).toHaveBeenCalledWith('/tasks', 'GET', undefined, {});
+  });
+
+  it('is a no-op when tasks.request is missing', () => {
+    const getAllTasks = jest.fn();
+    const client = {
+      tasks: { getAllTasks },
+    } as unknown as VikunjaClient;
+
+    expect(() => patchGetAllTasksForVikunja2(client)).not.toThrow();
+    expect(client.tasks.getAllTasks).toBe(getAllTasks);
+  });
+
+  it('is a no-op when tasks is missing', () => {
+    const client = {} as VikunjaClient;
+    expect(() => patchGetAllTasksForVikunja2(client)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #40: all-project task lists fail on Vikunja 2.x because `node-vikunja` 0.4.0 still calls `GET /tasks/all`.
- After each client is created, rebind `getAllTasks` to `GET /tasks` (the path Vikunja 2.x serves).
- Temporary shim until [node-vikunja#4](https://github.com/democratize-technology/node-vikunja/issues/4) ships and this package can bump the dependency.

## Test plan
- [x] Unit tests for the path shim
- [x] Factory test that patched `getAllTasks` hits `/tasks`
- [ ] CI green on this PR
- [ ] Confirm unscoped / all-projects task list works against Vikunja 2.3