### PR TITLE
fix(tasks): allow updating percentDone on create/update/bulk

### DIFF
--- a/src/tools/task-crud.ts
+++ b/src/tools/task-crud.ts
@@ -109,6 +109,8 @@ export function registerTaskCrudTool(
       projectId: z.number().optional(),
       dueDate: z.string().optional(),
       priority: z.number().min(0).max(5).optional(),
+      /** Completion percentage 0–100 (Vikunja percent_done) */
+      percentDone: z.number().min(0).max(100).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
       // Recurring task fields

--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -205,6 +205,7 @@ export async function bulkCreateTasks(args: BulkCreateArgs): Promise<{ content: 
         if (t.description !== undefined) newTask.description = t.description;
         if (t.dueDate !== undefined) newTask.due_date = t.dueDate;
         if (t.priority !== undefined) newTask.priority = t.priority;
+        if (t.percentDone !== undefined) newTask.percent_done = t.percentDone;
         if (t.repeatAfter !== undefined || t.repeatMode !== undefined) {
           const rc = convertRepeatConfiguration(t.repeatAfter, t.repeatMode);
           if (rc.repeat_after !== undefined) newTask.repeat_after = rc.repeat_after;

--- a/src/tools/tasks/bulk/BulkOperationValidator.ts
+++ b/src/tools/tasks/bulk/BulkOperationValidator.ts
@@ -21,6 +21,7 @@ export interface BulkCreateTaskData {
   description?: string;
   dueDate?: string;
   priority?: number;
+  percentDone?: number;
   labels?: number[];
   assignees?: number[];
   repeatAfter?: number;
@@ -100,6 +101,7 @@ export const bulkOperationValidator = {
       'labels',
       'repeat_after',
       'repeat_mode',
+      'percent_done',
     ];
 
     if (!args.field || !allowedFields.includes(args.field)) {
@@ -113,6 +115,15 @@ export const bulkOperationValidator = {
     if (args.field === 'priority' && typeof args.value === 'number') {
       if (args.value < 0 || args.value > 5) {
         throw new MCPError(ErrorCode.VALIDATION_ERROR, 'Priority must be between 0 and 5');
+      }
+    }
+
+    if (args.field === 'percent_done' && typeof args.value === 'number') {
+      if (args.value < 0 || args.value > 100) {
+        throw new MCPError(
+          ErrorCode.VALIDATION_ERROR,
+          'percent_done must be a number between 0 and 100',
+        );
       }
     }
 

--- a/src/tools/tasks/crud/TaskCreationService.ts
+++ b/src/tools/tasks/crud/TaskCreationService.ts
@@ -12,7 +12,7 @@ import { withRetry, RETRY_CONFIG } from '../../../utils/retry';
 import { transformApiError, handleFetchError } from '../../../utils/error-handler';
 import { sanitizeString } from '../../../utils/validation';
 import { AUTH_ERROR_MESSAGES } from '../constants';
-import { validateDateString, validateId, convertRepeatConfiguration } from '../validation';
+import { validateDateString, validateId, convertRepeatConfiguration, validatePercentDone } from '../validation';
 import { createTaskResponse } from './TaskResponseFormatter';
 import { formatAorpAsMarkdown } from '../../../utils/response-factory';
 
@@ -22,6 +22,8 @@ export interface CreateTaskArgs {
   description?: string;
   dueDate?: string;
   priority?: number;
+  /** Completion percentage (0–100), mapped to Vikunja `percent_done`. */
+  percentDone?: number;
   labels?: number[];
   assignees?: number[];
   repeatAfter?: number;
@@ -64,6 +66,10 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
       validateDateString(args.dueDate, 'dueDate');
     }
 
+    if (args.percentDone !== undefined) {
+      validatePercentDone(args.percentDone);
+    }
+
     // Validate assignee IDs upfront
     if (args.assignees && args.assignees.length > 0) {
       args.assignees.forEach((id) => validateId(id, 'assignee ID'));
@@ -81,6 +87,7 @@ export async function createTask(args: CreateTaskArgs): Promise<{ content: Array
     if (sanitizedDescription !== undefined) newTask.description = sanitizedDescription;
     if (args.dueDate !== undefined) newTask.due_date = args.dueDate;
     if (args.priority !== undefined) newTask.priority = args.priority;
+    if (args.percentDone !== undefined) newTask.percent_done = args.percentDone;
 
     // Handle repeat configuration
     if (args.repeatAfter !== undefined || args.repeatMode !== undefined) {

--- a/src/tools/tasks/crud/TaskUpdateService.ts
+++ b/src/tools/tasks/crud/TaskUpdateService.ts
@@ -6,7 +6,7 @@
 import { MCPError, ErrorCode } from '../../../types';
 import { getClientFromContext } from '../../../client';
 import type { Task, VikunjaClient } from 'node-vikunja';
-import { validateDateString, validateId, convertRepeatConfiguration } from '../validation';
+import { validateDateString, validateId, convertRepeatConfiguration, validatePercentDone } from '../validation';
 import { isAuthenticationError } from '../../../utils/auth-error-handler';
 import { RETRY_CONFIG } from '../../../utils/retry';
 import { transformApiError, handleFetchError, handleStatusCodeError } from '../../../utils/error-handler';
@@ -21,6 +21,8 @@ export interface UpdateTaskArgs {
   dueDate?: string;
   priority?: number;
   done?: boolean;
+  /** Completion percentage (0–100), mapped to Vikunja `percent_done`. */
+  percentDone?: number;
   labels?: number[];
   assignees?: number[];
   repeatAfter?: number;
@@ -51,6 +53,10 @@ export async function updateTask(args: UpdateTaskArgs): Promise<{ content: Array
     // Validate date if provided
     if (args.dueDate) {
       validateDateString(args.dueDate, 'dueDate');
+    }
+
+    if (args.percentDone !== undefined) {
+      validatePercentDone(args.percentDone);
     }
 
     const client = await getClientFromContext();
@@ -135,6 +141,7 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   if (currentTask.due_date !== undefined) previousState.due_date = currentTask.due_date;
   if (currentTask.priority !== undefined) previousState.priority = currentTask.priority;
   if (currentTask.done !== undefined) previousState.done = currentTask.done;
+  if (currentTask.percent_done !== undefined) previousState.percent_done = currentTask.percent_done;
   if (currentTask.repeat_after !== undefined) previousState.repeat_after = currentTask.repeat_after;
   if (currentTask.repeat_mode !== undefined) previousState.repeat_mode = currentTask.repeat_mode;
 
@@ -146,6 +153,9 @@ async function analyzeUpdateState(client: VikunjaClient, taskId: number, args: U
   if (args.dueDate !== undefined && args.dueDate !== currentTask.due_date) affectedFields.push('dueDate');
   if (args.priority !== undefined && args.priority !== currentTask.priority) affectedFields.push('priority');
   if (args.done !== undefined && args.done !== currentTask.done) affectedFields.push('done');
+  if (args.percentDone !== undefined && args.percentDone !== currentTask.percent_done) {
+    affectedFields.push('percentDone');
+  }
   if (args.repeatAfter !== undefined && args.repeatAfter !== currentTask.repeat_after) affectedFields.push('repeatAfter');
   if (args.repeatMode !== undefined && args.repeatMode !== currentTask.repeat_mode) affectedFields.push('repeatMode');
   if (args.labels !== undefined) affectedFields.push('labels');
@@ -171,6 +181,7 @@ function buildUpdateData(currentTask: Task, args: UpdateTaskArgs): Task {
     ...(args.dueDate !== undefined && { due_date: args.dueDate }),
     ...(args.priority !== undefined && { priority: args.priority }),
     ...(args.done !== undefined && { done: args.done }),
+    ...(args.percentDone !== undefined && { percent_done: args.percentDone }),
     // Handle repeat configuration for updates
     ...(args.repeatAfter !== undefined || args.repeatMode !== undefined
       ? ((): Record<string, unknown> => {

--- a/src/tools/tasks/index.ts
+++ b/src/tools/tasks/index.ts
@@ -153,6 +153,8 @@ export function registerTasksTool(
       projectId: z.number().optional(),
       dueDate: z.string().optional(),
       priority: z.number().min(0).max(5).optional(),
+      /** Completion percentage 0–100 (Vikunja percent_done) */
+      percentDone: z.number().min(0).max(100).optional(),
       labels: z.array(z.number()).optional(),
       assignees: z.array(z.number()).optional(),
       // Recurring task fields
@@ -183,6 +185,7 @@ export function registerTasksTool(
             description: z.string().optional(),
             dueDate: z.string().optional(),
             priority: z.number().min(0).max(5).optional(),
+            percentDone: z.number().min(0).max(100).optional(),
             labels: z.array(z.number()).optional(),
             assignees: z.array(z.number()).optional(),
             repeatAfter: z.number().min(0).optional(),

--- a/src/tools/tasks/validation.ts
+++ b/src/tools/tasks/validation.ts
@@ -26,6 +26,19 @@ export function validateDateString(date: string, fieldName: string): void {
 export const validateId = validateSharedId;
 
 /**
+ * Validates completion percentage for Vikunja `percent_done` (0–100).
+ */
+export function validatePercentDone(percentDone: number): void {
+  if (typeof percentDone !== 'number' || Number.isNaN(percentDone) ||
+      percentDone < 0 || percentDone > 100) {
+    throw new MCPError(
+      ErrorCode.VALIDATION_ERROR,
+      'percentDone must be a number between 0 and 100',
+    );
+  }
+}
+
+/**
  * Convert repeat configuration from user-friendly format to Vikunja API format
  *
  * Vikunja API expects:
@@ -107,6 +120,9 @@ export function applyFieldUpdate(task: Task, field: string | undefined, value: u
       break;
     case 'priority':
       task.priority = value as number;
+      break;
+    case 'percent_done':
+      task.percent_done = value as number;
       break;
     case 'due_date':
       task.due_date = value as string;

--- a/tests/tools/tasks-crud-edge-cases.test.ts
+++ b/tests/tools/tasks-crud-edge-cases.test.ts
@@ -288,6 +288,49 @@ describe('Tasks CRUD - Edge Cases and Defensive Programming', () => {
       expect(aorpStatus.type).toBe('success');
     });
 
+    it('should update percentDone on a task', async () => {
+      const currentTask = {
+        ...mockTask,
+        percent_done: 0,
+      };
+      const updatedTask = {
+        ...currentTask,
+        percent_done: 75,
+      };
+
+      mockClient.tasks.getTask
+        .mockResolvedValueOnce(currentTask)
+        .mockResolvedValueOnce(updatedTask);
+      mockClient.tasks.updateTask.mockResolvedValue(updatedTask);
+
+      const result = await updateTask({
+        id: 1,
+        percentDone: 75,
+      });
+
+      expect(mockClient.tasks.updateTask).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          percent_done: 75,
+        }),
+      );
+
+      const markdown = result.content[0].text;
+      const parsed = parseMarkdown(markdown);
+      expect(parsed.getAorpStatus().type).toBe('success');
+      expect(markdown).toContain('Task updated successfully');
+    });
+
+    it('should reject percentDone outside 0–100', async () => {
+      await expect(updateTask({ id: 1, percentDone: 101 })).rejects.toThrow(
+        'percentDone must be a number between 0 and 100',
+      );
+      await expect(updateTask({ id: 1, percentDone: -1 })).rejects.toThrow(
+        'percentDone must be a number between 0 and 100',
+      );
+      expect(mockClient.tasks.updateTask).not.toHaveBeenCalled();
+    });
+
     it('should handle empty assignee list updates', async () => {
       const taskWithAssignees = {
         ...mockTask,

--- a/tests/tools/tasks.test.ts
+++ b/tests/tools/tasks.test.ts
@@ -1563,7 +1563,7 @@ describe('Tasks Tool', () => {
           value: 'test',
         }),
       ).rejects.toThrow(
-        'Invalid field: invalid_field. Allowed fields: done, priority, due_date, project_id, assignees, labels',
+        'Invalid field: invalid_field. Allowed fields: done, priority, due_date, project_id, assignees, labels, repeat_after, repeat_mode, percent_done',
       );
     });
 

--- a/tests/tools/tasks/validation.test.ts
+++ b/tests/tools/tasks/validation.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, jest } from '@jest/globals';
 import {
   validateDateString,
   validateId,
+  validatePercentDone,
   convertRepeatConfiguration,
+  applyFieldUpdate,
   processBatches,
 } from '../../../src/tools/tasks/validation';
 import { MCPError, ErrorCode } from '../../../src/types';
@@ -57,6 +59,34 @@ describe('Validation utilities', () => {
       expect(() => validateId(1.5, 'testId')).toThrow(
         new MCPError(ErrorCode.VALIDATION_ERROR, 'testId must be a positive integer')
       );
+    });
+  });
+
+  describe('validatePercentDone', () => {
+    it('should accept values from 0 to 100', () => {
+      expect(() => validatePercentDone(0)).not.toThrow();
+      expect(() => validatePercentDone(50)).not.toThrow();
+      expect(() => validatePercentDone(100)).not.toThrow();
+    });
+
+    it('should reject values outside 0–100', () => {
+      expect(() => validatePercentDone(-1)).toThrow(
+        new MCPError(ErrorCode.VALIDATION_ERROR, 'percentDone must be a number between 0 and 100'),
+      );
+      expect(() => validatePercentDone(101)).toThrow(
+        new MCPError(ErrorCode.VALIDATION_ERROR, 'percentDone must be a number between 0 and 100'),
+      );
+      expect(() => validatePercentDone(Number.NaN)).toThrow(
+        new MCPError(ErrorCode.VALIDATION_ERROR, 'percentDone must be a number between 0 and 100'),
+      );
+    });
+  });
+
+  describe('applyFieldUpdate', () => {
+    it('should set percent_done on the task', () => {
+      const task = { title: 't', percent_done: 0 } as Parameters<typeof applyFieldUpdate>[0];
+      applyFieldUpdate(task, 'percent_done', 42);
+      expect(task.percent_done).toBe(42);
     });
   });
 


### PR DESCRIPTION
## Summary
- Expose `percentDone` (0–100) on task create/update tool schemas and services; maps to Vikunja `percent_done`
- Allow bulk-update field `percent_done` and pass-through on bulk-create
- Fixes #93 — gap was MCP-only; Vikunja’s API already supports the field

## Test plan
- [x] `npm run typecheck`
- [x] Jest: percentDone update success, range rejection, validation helper, applyFieldUpdate
- [ ] Optional: live MCP update `percentDone: 75` against a real Vikunja instance