### PR TITLE
fix(bulk): serialize SQLite writes and retry lock/5xx errors (fixes #79)

### DIFF
--- a/src/tools/tasks/bulk-operations-simplified.ts
+++ b/src/tools/tasks/bulk-operations-simplified.ts
@@ -3,9 +3,9 @@
  * Consolidates BulkOperationProcessor, BulkOperationErrorHandler, BulkOperationValidator, and BatchProcessorFactory
  */
 
-import { MCPError, ErrorCode, createStandardResponse, getClientFromContext, logger, isAuthenticationError, RETRY_CONFIG, transformApiError, handleFetchError } from '../../index';
+import { MCPError, ErrorCode, createStandardResponse, getClientFromContext, logger, isAuthenticationError, transformApiError, handleFetchError } from '../../index';
 import type { Assignee } from '../../types';
-import { withRetry } from '../../utils/retry';
+import { withRetry, isRetryableError, RETRY_CONFIG, type RetryOptions } from '../../utils/retry';
 import { BatchProcessor } from '../../utils/performance/batch-processor';
 import type { Task } from 'node-vikunja';
 import { convertRepeatConfiguration, applyFieldUpdate } from './validation';
@@ -16,11 +16,44 @@ import type { BulkUpdateArgs, BulkDeleteArgs, BulkCreateArgs, BulkCreateTaskData
 
 // ==================== BATCH PROCESSORS ====================
 
+/**
+ * SQLite (Vikunja's default DB) serializes writers. Parallel bulk writes hit
+ * "database is locked" → HTTP 500. Default to one write at a time; override with
+ * VIKUNJA_BULK_WRITE_CONCURRENCY when the backend can take more (e.g. Postgres).
+ */
+export function resolveBulkWriteConcurrency(fallback = 1): number {
+  const raw = process.env.VIKUNJA_BULK_WRITE_CONCURRENCY;
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return Math.min(parsed, 8);
+}
+
+const writeConcurrency = resolveBulkWriteConcurrency(1);
+
 const processors = {
-  update: new BatchProcessor({ maxConcurrency: 5, batchSize: 10, enableMetrics: true, batchDelay: 0 }),
-  delete: new BatchProcessor({ maxConcurrency: 3, batchSize: 5, enableMetrics: true, batchDelay: 100 }),
-  create: new BatchProcessor({ maxConcurrency: 8, batchSize: 15, enableMetrics: true, batchDelay: 0 }),
+  update: new BatchProcessor({ maxConcurrency: writeConcurrency, batchSize: 10, enableMetrics: true, batchDelay: 0 }),
+  delete: new BatchProcessor({ maxConcurrency: writeConcurrency, batchSize: 5, enableMetrics: true, batchDelay: 100 }),
+  create: new BatchProcessor({ maxConcurrency: writeConcurrency, batchSize: 15, enableMetrics: true, batchDelay: 0 }),
 };
+
+/** Built at call time so partial test mocks of RETRY_CONFIG cannot crash module load. */
+function bulkWriteRetryOptions(): RetryOptions {
+  return {
+    ...(RETRY_CONFIG.BULK_WRITES ?? {
+      maxRetries: 3,
+      initialDelay: 200,
+      maxDelay: 5000,
+      backoffFactor: 2,
+      enableCircuitBreaker: false,
+    }),
+    shouldRetry: isRetryableError,
+  };
+}
 
 // ==================== VALIDATION WRAPPERS ====================
 
@@ -61,7 +94,10 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
         const current = await client.tasks.getTask(taskId);
         const update = applyFieldUpdate({ ...current }, args.field, args.value);
 
-        const updated = await client.tasks.updateTask(taskId, update);
+        const updated = await withRetry(
+          () => client.tasks.updateTask(taskId, update),
+          bulkWriteRetryOptions(),
+        );
 
         if (args.field === 'assignees' && Array.isArray(args.value)) {
           const currentAssignees = (await client.tasks.getTask(taskId)).assignees?.map((a: Assignee) => a.id) || [];
@@ -90,8 +126,28 @@ export async function bulkUpdateTasks(args: BulkUpdateArgs): Promise<{ content: 
         if (firstError instanceof MCPError && firstError.message.includes('authentication')) throw firstError;
         throw new MCPError(ErrorCode.API_ERROR, `Bulk update failed. Could not update any tasks. Failed IDs: ${updateResult.failed.map(f => f.originalItem).join(', ')}`);
       }
-      return successResponse('update-task', `Successfully updated ${taskIds.length} tasks`, updateResult.successful, {
-        count: taskIds.length, affectedFields: [args.field], performanceMetrics: {
+      if (updateResult.failed.length > 0) {
+        const failedIds = updateResult.failed.map(f => f.originalItem);
+        return successResponse(
+          'update-task',
+          `Bulk update partially completed. Successfully updated ${updateResult.successful.length} tasks, ${updateResult.failed.length} failed.`,
+          updateResult.successful,
+          {
+            count: updateResult.successful.length,
+            failedCount: updateResult.failed.length,
+            failedIds,
+            affectedFields: [args.field],
+            success: false,
+            performanceMetrics: {
+              totalDuration: updateResult.metrics.totalDuration,
+              operationsPerSecond: updateResult.metrics.operationsPerSecond,
+              apiCallsUsed: updateResult.metrics.successfulOperations + updateResult.metrics.failedOperations,
+            },
+          },
+        );
+      }
+      return successResponse('update-task', `Successfully updated ${updateResult.successful.length} tasks`, updateResult.successful, {
+        count: updateResult.successful.length, affectedFields: [args.field], performanceMetrics: {
           totalDuration: updateResult.metrics.totalDuration, operationsPerSecond: updateResult.metrics.operationsPerSecond,
           apiCallsUsed: updateResult.metrics.successfulOperations + updateResult.metrics.failedOperations,
         },
@@ -158,7 +214,10 @@ export async function bulkDeleteTasks(args: BulkDeleteArgs): Promise<{ content: 
     const client = await getClientFromContext();
 
     const fetchResult = await processors.delete.processBatches(taskIds, async (id) => await client.tasks.getTask(id));
-    const deletionResult = await processors.delete.processBatches(taskIds, async (id) => { await client.tasks.deleteTask(id); return { taskId: id, deleted: true }; });
+    const deletionResult = await processors.delete.processBatches(taskIds, async (id) => {
+      await withRetry(() => client.tasks.deleteTask(id), bulkWriteRetryOptions());
+      return { taskId: id, deleted: true };
+    });
 
     if (deletionResult.failed.length > 0) {
       const failedIds = deletionResult.failed.map(f => f.originalItem);
@@ -211,7 +270,10 @@ export async function bulkCreateTasks(args: BulkCreateArgs): Promise<{ content: 
           if (rc.repeat_mode !== undefined) (newTask as Record<string, unknown>).repeat_mode = rc.repeat_mode;
         }
 
-        const created = await client.tasks.createTask(projectId, newTask);
+        const created = await withRetry(
+          () => client.tasks.createTask(projectId, newTask),
+          bulkWriteRetryOptions(),
+        );
         if (!created.id) return created;
 
         // Narrow type - id is guaranteed to exist after early return

--- a/src/tools/tasks/bulk-operations.ts
+++ b/src/tools/tasks/bulk-operations.ts
@@ -4,7 +4,7 @@
  * This file maintains backward compatibility while using the simplified implementation.
  */
 
-export { bulkUpdateTasks, bulkDeleteTasks, bulkCreateTasks } from './bulk-operations-simplified';
+export { bulkUpdateTasks, bulkDeleteTasks, bulkCreateTasks, resolveBulkWriteConcurrency } from './bulk-operations-simplified';
 
 // Re-export types from canonical location (BulkOperationValidator)
 export type {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -69,10 +69,16 @@ export interface RetryOptions {
   initialDelay?: number;
   backoffFactor?: number;
   maxDelay?: number;
+  /** When false, run the operation directly without a circuit breaker. Default true. */
+  enableCircuitBreaker?: boolean;
+  /** Named circuit breaker key. Defaults to a unique per-call name. */
+  circuitBreakerName?: string;
 }
 
 // Production-ready defaults
-const DEFAULT_OPTIONS: Required<Omit<RetryOptions, 'shouldRetry'>> = {
+const DEFAULT_OPTIONS: Required<
+  Omit<RetryOptions, 'shouldRetry' | 'enableCircuitBreaker' | 'circuitBreakerName'>
+> = {
   maxRetries: 3,
   timeout: 30000,
   resetTimeout: 30000,
@@ -124,13 +130,22 @@ export async function withRetry<T>(
   options: RetryOptions = {}
 ): Promise<T> {
   const opts = { ...DEFAULT_OPTIONS, ...options };
+  const enableCircuitBreaker = options.enableCircuitBreaker !== false;
   let lastError: unknown;
   let delay = opts.initialDelay || 1000;
+  const maxRetries = opts.maxRetries ?? 3;
 
-  for (let attempt = 0; attempt <= (opts.maxRetries || 3); attempt++) {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      // Use circuit breaker for the operation
-      const breaker = createCircuitBreaker(operation, 'anonymous', opts);
+      if (!enableCircuitBreaker) {
+        return await operation();
+      }
+      // Unique name per call unless the caller shares a family via circuitBreakerName.
+      // A hard-coded 'anonymous' breaker stays bound to the first operation it wrapped (#80).
+      const breakerName =
+        options.circuitBreakerName ||
+        `anonymous-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const breaker = createCircuitBreaker(operation, breakerName, opts);
       return await breaker.fire() as Promise<T>;
     } catch (error) {
       lastError = error;
@@ -141,12 +156,12 @@ export async function withRetry<T>(
         : isRetryableError(error as Error);
 
       // If this is the last attempt or error is not retryable, throw
-      if (attempt === (opts.maxRetries || 3) || !shouldRetry) {
+      if (attempt === maxRetries || !shouldRetry) {
         throw error;
       }
 
       // Log retry attempt
-      logger.debug(`Retry attempt ${attempt + 1}/${opts.maxRetries || 3} after ${delay}ms`);
+      logger.debug(`Retry attempt ${attempt + 1}/${maxRetries} after ${delay}ms`);
 
       // Wait before retrying with exponential backoff
       await new Promise(resolve => setTimeout(resolve, delay));
@@ -182,7 +197,29 @@ export function getHealthStats(breaker: CircuitBreaker): CircuitBreaker.Stats {
 }
 
 /**
- * Check if error is retryable (basic implementation)
+ * Best-effort HTTP status from Error-like objects (node-vikunja / fetch wrappers).
+ */
+function getHttpStatus(error: unknown): number | undefined {
+  if (error === null || typeof error !== 'object') {
+    return undefined;
+  }
+  const e = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown };
+  };
+  const candidates = [e.statusCode, e.status, e.response?.status];
+  for (const value of candidates) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Check if error is retryable (basic implementation).
+ * Includes transient Vikunja/SQLite write failures ("database is locked" → HTTP 500).
  */
 export function isRetryableError(error: unknown): error is ErrorWithCode {
   if (error instanceof Error) {
@@ -191,11 +228,19 @@ export function isRetryableError(error: unknown): error is ErrorWithCode {
       return true;
     }
 
+    const status = getHttpStatus(error);
+    if (status === 429 || (typeof status === 'number' && status >= 500 && status < 600)) {
+      return true;
+    }
+
     const message = error.message.toLowerCase();
     return message.includes('timeout') ||
            message.includes('connection') ||
            message.includes('network') ||
            message.includes('rate limit') ||
+           message.includes('internal server error') ||
+           message.includes('database is locked') ||
+           message.includes('sqlite_busy') ||
            (error as ErrorWithCode).code === 'ECONNRESET' ||
            (error as ErrorWithCode).code === 'ETIMEDOUT';
   }
@@ -207,6 +252,11 @@ export function isRetryableError(error: unknown): error is ErrorWithCode {
  */
 export function isTransientError(error: unknown): error is ErrorWithCode {
   if (error instanceof Error) {
+    const status = getHttpStatus(error);
+    if (status === 429 || (typeof status === 'number' && status >= 500 && status < 600)) {
+      return true;
+    }
+
     const message = error.message.toLowerCase();
     return message.includes('timeout') ||
            message.includes('timed out') ||
@@ -219,6 +269,9 @@ export function isTransientError(error: unknown): error is ErrorWithCode {
            message.includes('etimedout') ||
            message.includes('reset by peer') ||
            message.includes('closed unexpectedly') ||
+           message.includes('internal server error') ||
+           message.includes('database is locked') ||
+           message.includes('sqlite_busy') ||
            (error as ErrorWithCode).code === 'ECONNRESET' ||
            (error as ErrorWithCode).code === 'ETIMEDOUT';
   }
@@ -260,6 +313,18 @@ export const RETRY_CONFIG = {
     backoffFactor: 1.5,
     enableCircuitBreaker: true,
     circuitBreakerName: 'vikunja-bulk-operations'
+  },
+  /**
+   * Per-item bulk writes against SQLite-backed Vikunja.
+   * No shared circuit breaker: one locked write must not trip the rest of the batch,
+   * and must not hit the registry-cached 'anonymous' breaker (see #80).
+   */
+  BULK_WRITES: {
+    maxRetries: 3,
+    initialDelay: 200,
+    maxDelay: 5000,
+    backoffFactor: 2,
+    enableCircuitBreaker: false,
   }
 } as const;
 

--- a/tests/circuit-breaker-integration.test.ts
+++ b/tests/circuit-breaker-integration.test.ts
@@ -52,7 +52,7 @@ describe('Circuit Breaker Integration with Retry Logic', () => {
     const results = await Promise.all(promises);
 
     // At least one should be blocked by circuit breaker
-    expect(results.some(r => r.includes('Circuit breaker') && r.includes('OPEN'))).toBe(true);
+    expect(results.some(r => /breaker is open/i.test(r))).toBe(true);
 
     // Verify the operation was indeed blocked (limited calls)
     expect(mockOperation).toHaveBeenCalledTimes(5); // Opened after 5 failures (default threshold)

--- a/tests/tools/tasks/bulk-operations.test.ts
+++ b/tests/tools/tasks/bulk-operations.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { bulkUpdateTasks, bulkDeleteTasks, bulkCreateTasks } from '../../../src/tools/tasks/bulk-operations';
+import { bulkUpdateTasks, bulkDeleteTasks, bulkCreateTasks, resolveBulkWriteConcurrency } from '../../../src/tools/tasks/bulk-operations';
 import { getClientFromContext } from '../../../src/client';
 import { MCPError, ErrorCode } from '../../../src/types';
 import { isAuthenticationError } from '../../../src/utils/auth-error-handler';
@@ -16,6 +16,35 @@ jest.mock('../../../src/utils/retry');
 jest.mock('../../../src/utils/logger');
 
 describe('Bulk operations', () => {
+  it('resolveBulkWriteConcurrency defaults and clamps env overrides', () => {
+    const previous = process.env.VIKUNJA_BULK_WRITE_CONCURRENCY;
+    try {
+      delete process.env.VIKUNJA_BULK_WRITE_CONCURRENCY;
+      expect(resolveBulkWriteConcurrency(1)).toBe(1);
+
+      process.env.VIKUNJA_BULK_WRITE_CONCURRENCY = '';
+      expect(resolveBulkWriteConcurrency(2)).toBe(2);
+
+      process.env.VIKUNJA_BULK_WRITE_CONCURRENCY = 'nope';
+      expect(resolveBulkWriteConcurrency(1)).toBe(1);
+
+      process.env.VIKUNJA_BULK_WRITE_CONCURRENCY = '0';
+      expect(resolveBulkWriteConcurrency(1)).toBe(1);
+
+      process.env.VIKUNJA_BULK_WRITE_CONCURRENCY = '3';
+      expect(resolveBulkWriteConcurrency(1)).toBe(3);
+
+      process.env.VIKUNJA_BULK_WRITE_CONCURRENCY = '99';
+      expect(resolveBulkWriteConcurrency(1)).toBe(8);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.VIKUNJA_BULK_WRITE_CONCURRENCY;
+      } else {
+        process.env.VIKUNJA_BULK_WRITE_CONCURRENCY = previous;
+      }
+    }
+  });
+
   const mockClient = {
     tasks: {
       bulkUpdateTasks: jest.fn(),
@@ -249,6 +278,25 @@ describe('Bulk operations', () => {
         expect(markdown).toContain("## ✅ Success");
       });
 
+      it('should report partial failure instead of fake full success (issue #79)', async () => {
+        mockClient.tasks.bulkUpdateTasks.mockRejectedValue(new Error('Bulk API failed'));
+        mockClient.tasks.getTask
+          .mockResolvedValueOnce({ id: 1, title: 'ok', project_id: 1, done: false })
+          .mockResolvedValueOnce({ id: 2, title: 'fail', project_id: 1, done: false });
+        mockClient.tasks.updateTask
+          .mockResolvedValueOnce({ id: 1, title: 'ok', project_id: 1, done: true })
+          .mockRejectedValueOnce(new Error('Internal Server Error'));
+
+        const result = await bulkUpdateTasks({ taskIds: [1, 2], field: 'done', value: true });
+        const markdown = result.content[0].text;
+        const parsed = parseMarkdown(markdown);
+
+        expect(parsed.hasHeading(2, /Error/)).toBe(true);
+        expect(markdown).toContain('Bulk update partially completed');
+        expect(markdown).toContain('Successfully updated 1 tasks, 1 failed');
+        expect(markdown).toContain('**FailedCount**:');
+      });
+
       it('should handle assignees field in fallback mode', async () => {
         const bulkError = new Error('Bulk API failed');
         const mockTask = { id: 1, title: 'Task 1', assignees: [] };
@@ -279,7 +327,14 @@ describe('Bulk operations', () => {
         mockClient.tasks.bulkUpdateTasks.mockRejectedValue(bulkError);
         mockClient.tasks.getTask.mockResolvedValue({ id: 1, title: 'Task 1', assignees: [] });
         mockClient.tasks.updateTask.mockResolvedValue({ id: 1, title: 'Task 1' });
-        (withRetry as jest.Mock).mockRejectedValue(authError);
+        let retryCalls = 0;
+        (withRetry as jest.Mock).mockImplementation((fn: () => Promise<unknown>) => {
+          retryCalls += 1;
+          if (retryCalls === 1) {
+            return fn();
+          }
+          return Promise.reject(authError);
+        });
         (isAuthenticationError as jest.Mock).mockReturnValue(true);
 
         await expect(bulkUpdateTasks({ taskIds: [1], field: 'assignees', value: [1] })).rejects.toThrow(
@@ -540,7 +595,14 @@ describe('Bulk operations', () => {
         const authError = new Error('Authentication failed');
         
         mockClient.tasks.createTask.mockResolvedValue(mockTask);
-        (withRetry as jest.Mock).mockRejectedValue(authError);
+        let retryCalls = 0;
+        (withRetry as jest.Mock).mockImplementation((fn: () => Promise<unknown>) => {
+          retryCalls += 1;
+          if (retryCalls === 1) {
+            return fn();
+          }
+          return Promise.reject(authError);
+        });
         (isAuthenticationError as jest.Mock).mockReturnValue(true);
         mockClient.tasks.deleteTask.mockResolvedValue({});
 
@@ -635,7 +697,14 @@ describe('Bulk operations', () => {
         const deleteError = new Error('Cleanup failed');
         
         mockClient.tasks.createTask.mockResolvedValue(mockTask);
-        (withRetry as jest.Mock).mockRejectedValue(labelError);
+        let retryCalls = 0;
+        (withRetry as jest.Mock).mockImplementation((fn: () => Promise<unknown>) => {
+          retryCalls += 1;
+          if (retryCalls === 1) {
+            return fn();
+          }
+          return Promise.reject(labelError);
+        });
         mockClient.tasks.deleteTask.mockRejectedValue(deleteError);
 
         await expect(bulkCreateTasks({ 

--- a/tests/utils/retry.test.ts
+++ b/tests/utils/retry.test.ts
@@ -1,4 +1,4 @@
-import { withRetry, isTransientError, RETRY_CONFIG } from '../../src/utils/retry';
+import { withRetry, isTransientError, isRetryableError, RETRY_CONFIG } from '../../src/utils/retry';
 import { isAuthenticationError } from '../../src/utils/auth-error-handler';
 import { logger } from '../../src/utils/logger';
 
@@ -185,15 +185,15 @@ describe('retry utility', () => {
       
       // First retry: 100ms
       await jest.advanceTimersByTimeAsync(100);
-      expect(debugCalls[0].msg).toContain('Retrying operation after 100ms');
+      expect(debugCalls[0].msg).toContain('Retry attempt 1/3 after 100ms');
       
       // Second retry: 200ms (100 * 2^1)
       await jest.advanceTimersByTimeAsync(200);
-      expect(debugCalls[1].msg).toContain('Retrying operation after 200ms');
+      expect(debugCalls[1].msg).toContain('Retry attempt 2/3 after 200ms');
       
       // Third retry: 400ms (100 * 2^2)
       await jest.advanceTimersByTimeAsync(400);
-      expect(debugCalls[2].msg).toContain('Retrying operation after 400ms');
+      expect(debugCalls[2].msg).toContain('Retry attempt 3/3 after 400ms');
       
       await expect(promise).rejects.toThrow('Error');
     });
@@ -227,6 +227,14 @@ describe('retry utility', () => {
       expect(isTransientError(new Error('Not found'))).toBe(false);
     });
 
+    it('should identify SQLite lock and HTTP 5xx as transient', () => {
+      expect(isTransientError(new Error('database is locked'))).toBe(true);
+      expect(isTransientError(new Error('Internal Server Error'))).toBe(true);
+      const statusError = new Error('server boom');
+      (statusError as Error & { statusCode: number }).statusCode = 503;
+      expect(isTransientError(statusError)).toBe(true);
+    });
+
     it('should handle non-Error objects', () => {
       expect(isTransientError('string error')).toBe(false);
       expect(isTransientError(null)).toBe(false);
@@ -238,6 +246,68 @@ describe('retry utility', () => {
       expect(isTransientError(new Error('TIMEOUT'))).toBe(true);
       expect(isTransientError(new Error('Network Error'))).toBe(true);
       expect(isTransientError(new Error('SOCKET HANG UP'))).toBe(true);
+    });
+  });
+
+  describe('isRetryableError', () => {
+    it('should retry Internal Server Error and SQLite lock messages', () => {
+      expect(isRetryableError(new Error('Internal Server Error'))).toBe(true);
+      expect(isRetryableError(new Error('database is locked'))).toBe(true);
+      expect(isRetryableError(new Error('SQLITE_BUSY: database is locked'))).toBe(true);
+    });
+
+    it('should retry HTTP 5xx and 429 via status fields', () => {
+      const locked = new Error('write failed');
+      (locked as Error & { status: number }).status = 500;
+      expect(isRetryableError(locked)).toBe(true);
+
+      const rateLimited = new Error('slow down');
+      (rateLimited as Error & { statusCode: number }).statusCode = 429;
+      expect(isRetryableError(rateLimited)).toBe(true);
+
+      const nested = new Error('upstream');
+      (nested as Error & { response: { status: number } }).response = { status: 502 };
+      expect(isRetryableError(nested)).toBe(true);
+
+      const nonNumeric = new Error('weird status');
+      (nonNumeric as Error & { status: string }).status = '500';
+      expect(isRetryableError(nonNumeric)).toBe(false);
+    });
+
+    it('should not retry client validation errors', () => {
+      expect(isRetryableError(new Error('Invalid input'))).toBe(false);
+      const notFound = new Error('missing');
+      (notFound as Error & { statusCode: number }).statusCode = 404;
+      expect(isRetryableError(notFound)).toBe(false);
+    });
+
+    it('should not retry when maxRetries is 0', async () => {
+      const error = new Error('Internal Server Error');
+      (error as Error & { status: number }).status = 500;
+      const operation = jest.fn().mockRejectedValue(error);
+
+      await expect(
+        withRetry(operation, { enableCircuitBreaker: false, maxRetries: 0 }),
+      ).rejects.toThrow('Internal Server Error');
+      expect(operation).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry a lock error then succeed without a circuit breaker', async () => {
+      jest.useFakeTimers();
+      const lockError = new Error('Internal Server Error');
+      (lockError as Error & { status: number }).status = 500;
+      const operation = jest.fn()
+        .mockRejectedValueOnce(lockError)
+        .mockResolvedValueOnce('created');
+
+      const promise = withRetry(operation, {
+        enableCircuitBreaker: false,
+        initialDelay: 100,
+      });
+      await jest.advanceTimersByTimeAsync(100);
+      await expect(promise).resolves.toBe('created');
+      expect(operation).toHaveBeenCalledTimes(2);
+      jest.useRealTimers();
     });
   });
 
@@ -261,6 +331,16 @@ describe('retry utility', () => {
         backoffFactor: 1.5,
         enableCircuitBreaker: true,
         circuitBreakerName: 'vikunja-api-operations'
+      });
+    });
+
+    it('should have BULK_WRITES configuration without a shared breaker', () => {
+      expect(RETRY_CONFIG.BULK_WRITES).toEqual({
+        maxRetries: 3,
+        initialDelay: 200,
+        maxDelay: 5000,
+        backoffFactor: 2,
+        enableCircuitBreaker: false,
       });
     });
   });


### PR DESCRIPTION
## Summary
- Default bulk create/update/delete write concurrency to **1** so SQLite-backed Vikunja (official Docker default) no longer loses random tasks to `database is locked` / HTTP 500. Override with `VIKUNJA_BULK_WRITE_CONCURRENCY` when the DB can take more (e.g. Postgres).
- Retry per-item writes on transient 5xx, 429, `Internal Server Error`, and `database is locked` via new `RETRY_CONFIG.BULK_WRITES` (`enableCircuitBreaker: false` so one lock does not trip the batch or the shared `'anonymous'` breaker).
- Bulk-update fallback now reports **partial failure** instead of claiming full success when some tasks fail.
- `withRetry`: honor `enableCircuitBreaker` / `circuitBreakerName`, treat `maxRetries: 0` as zero retries (`??` not `||`), and use unique breaker names when none is provided (avoids replaying the first wrapped operation).

Fixes #79

Shipped and tested on [`joyjit/vikunja-mcp#25`](https://github.com/joyjit/vikunja-mcp/pull/25).

## Test plan
- [x] `npx jest tests/utils/retry.test.ts tests/tools/tasks/bulk-operations.test.ts tests/circuit-breaker-integration.test.ts`
- [x] `npm run typecheck && npm run lint`
- [ ] CI on this PR
- [ ] Optional: `npm run test:mcp` (ephemeral SQLite Vikunja) — bulk-create 12 tasks should be 12/12